### PR TITLE
urgh, python, amirite

### DIFF
--- a/DataModel/SlowControlCollection.cpp
+++ b/DataModel/SlowControlCollection.cpp
@@ -173,8 +173,8 @@ void SlowControlCollection::Thread(Thread_args* arg){
 	if(value=="") value="1";
 	if((*args->SCC)[key]){
 	  (*args->SCC)[key]->SetValue(value);
-	  std::function<std::string(std::string)> tmp_func= (*args->SCC)[key]->GetFunction();
-	  if (tmp_func!=nullptr) reply=tmp_func(key);
+	  std::function<std::string(const char*)> tmp_func= (*args->SCC)[key]->GetFunction();
+	  if (tmp_func!=nullptr) reply=tmp_func(key.c_str());
 	  //std::cout<<"value="<<value<<std::endl;
 	}
       }
@@ -204,7 +204,7 @@ void SlowControlCollection::Thread(Thread_args* arg){
     std::istringstream iss(static_cast<char*>(message.data()));
     //std::cout<<iss.str()<<std::endl;
     args->trigger_functions_mutex->lock();
-    if(args->trigger_functions->count(iss.str())) (*(args->trigger_functions))[iss.str()](iss.str());
+    if(args->trigger_functions->count(iss.str())) (*(args->trigger_functions))[iss.str()](iss.str().c_str());
     args->trigger_functions_mutex->unlock();
   } 
 
@@ -223,7 +223,7 @@ void SlowControlCollection::Clear(){
 }
 
 
-bool SlowControlCollection::Add(std::string name, SlowControlElementType type, std::function<std::string(std::string)> function){
+bool SlowControlCollection::Add(std::string name, SlowControlElementType type, std::function<std::string(const char*)> function){
 
   if(SC_vars.count(name)) return false;
   SC_vars[name] = new SlowControlElement(name, type, function);
@@ -265,7 +265,7 @@ std::string SlowControlCollection::Print(){
   
 }
 
-bool SlowControlCollection::TriggerSubscribe(std::string trigger, std::function<void(std::string)> function){
+bool SlowControlCollection::TriggerSubscribe(std::string trigger, std::function<void(const char*)> function){
 
   if(function==nullptr) return false;
   m_trigger_functions_mutex.lock(); 

--- a/DataModel/SlowControlCollection.h
+++ b/DataModel/SlowControlCollection.h
@@ -19,7 +19,7 @@ struct SlowControlCollectionThread_args:Thread_args{
   int poll_length;
 
   SlowControlCollection* SCC;
-  std::map<std::string, std::function<void(std::string)> >* trigger_functions;  
+  std::map<std::string, std::function<void(const char*)> >* trigger_functions;
   std::mutex* trigger_functions_mutex;
 
 };
@@ -35,10 +35,10 @@ class SlowControlCollection{
   bool ListenForData(int poll_length=0);
   bool InitThreadedReceiver(zmq::context_t* context, int port=555, int poll_length=100, bool new_service=true);
   SlowControlElement* operator[](std::string key);
-  bool Add(std::string name, SlowControlElementType type, std::function<std::string(std::string)> function=nullptr);
+  bool Add(std::string name, SlowControlElementType type, std::function<std::string(const char*)> function=nullptr);
   bool Remove(std::string name);
   void Clear();
-  bool TriggerSubscribe(std::string trigger, std::function<void(std::string)> function);
+  bool TriggerSubscribe(std::string trigger, std::function<void(const char*)> function);
   bool TriggerSend(std::string trigger);
   std::string Print();
   template<typename T> T GetValue(std::string name){
@@ -51,7 +51,7 @@ class SlowControlCollection{
  private:
 
   std::map<std::string, SlowControlElement*> SC_vars;
-  std::map<std::string, std::function<void(std::string)> > m_trigger_functions;
+  std::map<std::string, std::function<void(const char*)> > m_trigger_functions;
   std::mutex m_trigger_functions_mutex;
   
   DAQUtilities* m_util;

--- a/DataModel/SlowControlElement.cpp
+++ b/DataModel/SlowControlElement.cpp
@@ -1,6 +1,6 @@
 #include <SlowControlElement.h>
 
-SlowControlElement::SlowControlElement(std::string name, SlowControlElementType type, std::function<std::string(std::string)> function){
+SlowControlElement::SlowControlElement(std::string name, SlowControlElementType type, std::function<std::string(const char*)> function){
 
   m_name=name;
   m_type=type;
@@ -78,7 +78,7 @@ std::string SlowControlElement::Print(){
 }
 
 
-std::function<std::string(std::string)> SlowControlElement::GetFunction(){
+std::function<std::string(const char*)> SlowControlElement::GetFunction(){
 
   return m_function;
 

--- a/DataModel/SlowControlElement.h
+++ b/DataModel/SlowControlElement.h
@@ -15,11 +15,11 @@ class SlowControlElement{
 
  public:
  
-  SlowControlElement(std::string name, SlowControlElementType type,  std::function<std::string(std::string)> function=nullptr);
+  SlowControlElement(std::string name, SlowControlElementType type,  std::function<std::string(const char*)> function=nullptr);
   std::string GetName();
   bool IsName(std::string name);
   std::string Print();
-  std::function<std::string(std::string)> GetFunction();
+  std::function<std::string(const char*)> GetFunction();
   SlowControlElementType GetType();
   
   template<typename T> bool SetMin(T value){ 
@@ -155,7 +155,7 @@ class SlowControlElement{
   SlowControlElementType m_type;
   Store options;
   unsigned int num_options;
-  std::function<std::string(std::string)> m_function;
+  std::function<std::string(const char*)> m_function;
 
   std::mutex mtx;
  


### PR DESCRIPTION
change SlowControlElement registered functions to use const char* instead of std::string, because python callbacks segfault if they receive a std::string.