### PR TITLE
Call set value callback for BUTTON type variables

### DIFF
--- a/src/ServiceDiscovery/SlowControlCollection.cpp
+++ b/src/ServiceDiscovery/SlowControlCollection.cpp
@@ -224,6 +224,8 @@ void SlowControlCollection::Thread(Thread_args* arg){
         reply=value;
       }
       else if((*args->SCC)[key]->GetType() == SlowControlElementType(BUTTON)){
+        SCFunction tmp_func= (*args->SCC)[key]->GetChangeFunction();
+	      if (tmp_func!=nullptr) reply=tmp_func(key.c_str());
 	(*args->SCC)[key]->SetValue("1");
 	reply=key;
       }

--- a/src/ServiceDiscovery/SlowControlCollection.cpp
+++ b/src/ServiceDiscovery/SlowControlCollection.cpp
@@ -225,7 +225,7 @@ void SlowControlCollection::Thread(Thread_args* arg){
       }
       else if((*args->SCC)[key]->GetType() == SlowControlElementType(BUTTON)){
         SCFunction tmp_func= (*args->SCC)[key]->GetChangeFunction();
-	      if (tmp_func!=nullptr) reply=tmp_func(key.c_str());
+	      if (tmp_func!=nullptr) tmp_func(key.c_str());
 	(*args->SCC)[key]->SetValue("1");
 	reply=key;
       }


### PR DESCRIPTION
No callback was called when the BUTTON type variable change request was received.
This patch ignores the return value from the callback - should we use it?