### PR TITLE
Replace generic plots with Plotly specific plots

### DIFF
--- a/src/ServiceDiscovery/Services.h
+++ b/src/ServiceDiscovery/Services.h
@@ -20,16 +20,6 @@
 
 namespace ToolFramework {
 
-  struct Plot {
-    std::string name;
-    std::string title;
-    std::string xlabel;
-    std::string ylabel;
-    std::vector<float> x;
-    std::vector<float> y;
-    Store info;
-  };
-  
   class Services{
     
     
@@ -59,8 +49,8 @@ namespace ToolFramework {
     bool SendTemporaryROOTplot(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, int* version=nullptr, const unsigned int timestamp=0);
     bool SendPersistentROOTplot(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, int* version=nullptr, const unsigned int timestamp=0, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     bool GetROOTplot(const std::string& plot_name, int& version, std::string& draw_option, std::string& json_data, std::string* timestamp=nullptr, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool SendPlot(Plot& plot, unsigned timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool GetPlot(const std::string& name, Plot& plot, unsigned timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool SendPlotlyPlot(const std::string& name, const std::string& json_trace, const std::string& json_layout="{}", int* version=nullptr, unsigned int timestamp=0, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool GetPlotlyPlot(const std::string& name, int& version, std::string& json_trace, std::string& json_layout, unsigned int* timestamp=nullptr, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     
     SlowControlCollection* GetSlowControlCollection();
     SlowControlElement* GetSlowControlVariable(std::string key);

--- a/src/ServiceDiscovery/Services.h
+++ b/src/ServiceDiscovery/Services.h
@@ -50,6 +50,7 @@ namespace ToolFramework {
     bool SendPersistentROOTplot(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, int* version=nullptr, const unsigned int timestamp=0, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     bool GetROOTplot(const std::string& plot_name, int& version, std::string& draw_option, std::string& json_data, std::string* timestamp=nullptr, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     bool SendPlotlyPlot(const std::string& name, const std::string& json_trace, const std::string& json_layout="{}", int* version=nullptr, unsigned int timestamp=0, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool SendPlotlyPlot(const std::string& name, const std::vector<std::string>& json_traces, const std::string& json_layout="{}", int* version=nullptr, unsigned int timestamp=0, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     bool GetPlotlyPlot(const std::string& name, int& version, std::string& json_trace, std::string& json_layout, unsigned int* timestamp=nullptr, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     
     SlowControlCollection* GetSlowControlCollection();


### PR DESCRIPTION
Instead of storing a generic plot in the database, store two JSON objects --- trace and layout --- that are arguments to Plotly plotting functions.