### PR TITLE
bugfix to SlowControlCollection.cpp

### DIFF
--- a/src/ServiceDiscovery/SlowControlCollection.cpp
+++ b/src/ServiceDiscovery/SlowControlCollection.cpp
@@ -239,7 +239,6 @@ void SlowControlCollection::Thread(Thread_args* arg){
       else{
 	reply=key;
 	if((*args->SCC)[key]->GetType() == SlowControlElementType(BUTTON)){
-	  (*args->SCC)[key]->SetValue("1");
 	  value="1";
 	}
         //std::stringstream input;


### PR DESCRIPTION
Remove redundant call to SlowControlElement::SetValue for buttons, which may result in firing callbacks twice.