### PR TITLE
Remove startup delay in Services constructor

### DIFF
--- a/src/ServiceDiscovery/Services.cpp
+++ b/src/ServiceDiscovery/Services.cpp
@@ -27,17 +27,16 @@ bool Services::Init(Store &m_variables, zmq::context_t* context_in, SlowControlC
   if(!m_variables.Get("service_name",m_name)) m_name="test_service";
   if(!m_variables.Get("db_name",m_dbname)) m_dbname="daq";
   
-  
-    
   if(!m_backend_client.Initialise(m_variables)){
     std::clog<<"error initialising slowcontrol client"<<std::endl;
     return false;
   }
    
-  // TODO FIXME with better mechanism
-  // after Initilising the slow control client needs ~15 seconds for the middleman to connect
-  std::this_thread::sleep_for(std::chrono::seconds(15));
-  // hopefully the middleman has found us by now
+  // wait for the middleman to connect. ServiceDiscovery broadcasts are sent out intermittently,
+  // so we need to wait for the middleman to receive one & connect before we can communicate with it.
+  int pub_period=5;
+  m_variables.Get("service_publish_sec",pub_period);
+  Ready(pub_period*1000);
   
   return true;
 }

--- a/src/ServiceDiscovery/Services.cpp
+++ b/src/ServiceDiscovery/Services.cpp
@@ -42,6 +42,10 @@ bool Services::Init(Store &m_variables, zmq::context_t* context_in, SlowControlC
   return true;
 }
 
+bool Services::Ready(const unsigned int timeout){
+  return m_backend_client.Ready(timeout);
+}
+
 // ===========================================================================
 // Write Functions
 // ---------------

--- a/src/ServiceDiscovery/Services.h
+++ b/src/ServiceDiscovery/Services.h
@@ -38,6 +38,7 @@ namespace ToolFramework {
     Services();
     ~Services();
     bool Init(Store &m_variables, zmq::context_t* context_in, SlowControlCollection* sc_vars_in, bool new_service=false);
+    bool Ready(const unsigned int timeout=10000); // default service discovery broadcast period is 5s, middleman also checks intermittently, compound total time should be <10s...
     
     bool SQLQuery(const std::string& database, const std::string& query, std::vector<std::string>& responses, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     bool SQLQuery(const std::string& database, const std::string& query, std::string& response, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);

--- a/src/ServiceDiscovery/ServicesBackend.cpp
+++ b/src/ServiceDiscovery/ServicesBackend.cpp
@@ -943,7 +943,9 @@ bool ServicesBackend::Ready(int timeout){
 	// polling the input socket checks for a message, so don't do that.
 	int ret;
 	try {
+		dlr_socket_mutex.lock();
 		ret = zmq::poll(&out_polls.at(1), 1, timeout);
+		dlr_socket_mutex.unlock();
 	} catch (zmq::error_t& err){
 		std::cerr<<"ServicesBackend::Ready caught "<<err.what()<<std::endl;
 		return false;

--- a/src/ServiceDiscovery/ServicesBackend.h
+++ b/src/ServiceDiscovery/ServicesBackend.h
@@ -51,6 +51,7 @@ class ServicesBackend {
 	ServicesBackend(){};
 	~ServicesBackend(){};
 	void SetUp(zmq::context_t* in_context, std::function<void(std::string msg, int msg_verb, int verbosity)> log=nullptr); // possibly move to constructor
+	bool Ready(int timeout); // check if zmq sockets have connections
 	bool Initialise(std::string configfile);
 	bool Initialise(Store &varaibles_in);
 	bool Finalise();


### PR DESCRIPTION
and replace with a call to Ready (poll zmq output sockets for listener). This only waits as long as is necessary.
Builds on PR #35 