### PR TITLE
important safety check in SlowControlCollection.h

### DIFF
--- a/src/ServiceDiscovery/SlowControlCollection.h
+++ b/src/ServiceDiscovery/SlowControlCollection.h
@@ -53,6 +53,7 @@ namespace ToolFramework{
     
     
     template<typename T> T GetValue(std::string name){
+      if(!SC_vars.count(name)) return T{};
       return SC_vars[name]->GetValue<T>();
     }
     


### PR DESCRIPTION
Check requested control exists in templated GetValue method.

Note that this simply returns a default-constructed value, but does not communicate to the user that the requested control was not found. This could lead to some subtle and hard-to-find bugs if typos are made in `Get` calls. :( 

Similar behaviour is affected by the SlowControlElement class GetValue method. 