### PR TITLE
add linger setting to zmq sockets in ServicesBackend.cpp

### DIFF
--- a/src/ServiceDiscovery/ServicesBackend.cpp
+++ b/src/ServiceDiscovery/ServicesBackend.cpp
@@ -229,12 +229,14 @@ bool ServicesBackend::InitZMQ(){
 	// socket to publish write commands
 	// -------------------------------
 	clt_pub_socket = new zmq::socket_t(*context, ZMQ_PUB);
+	clt_pub_socket->setsockopt(ZMQ_LINGER,10);
 	clt_pub_socket->setsockopt(ZMQ_SNDTIMEO, clt_pub_socket_timeout);
 	clt_pub_socket->bind(std::string("tcp://*:")+std::to_string(clt_pub_port));
 	
 	// socket to deal read commands and receive responses
 	// -------------------------------------------------
 	clt_dlr_socket = new zmq::socket_t(*context, ZMQ_DEALER);
+	clt_dlr_socket->setsockopt(ZMQ_LINGER,10);
 	clt_dlr_socket->setsockopt(ZMQ_SNDTIMEO, clt_dlr_socket_timeout);
 	clt_dlr_socket->setsockopt(ZMQ_RCVTIMEO, clt_dlr_socket_timeout);
 	clt_dlr_socket->setsockopt(ZMQ_IDENTITY, clt_ID.c_str(), clt_ID.length());


### PR DESCRIPTION
Add 10ms linger to prevent application hanging on shutdown if there are unsent messages