### PR TITLE
Updates for Middleman v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 *.pcm
 # python pre-compiled modules
 *.pyc
+# core dumps
+core
 
 # lib folder is populated during build
 lib/
@@ -23,3 +25,4 @@ tempinclude/
 main
 NodeDaemon
 RemoteControl
+MCDebug

--- a/configfiles/Dummy/ToolChainConfig
+++ b/configfiles/Dummy/ToolChainConfig
@@ -18,8 +18,8 @@ log_interactive 1	# Interactive=cout; 0=false, 1= true
 log_local 1 		# Local = local file log; 0=false, 1= true
 log_local_path ./log 	# file to store logs to if local is active
 log_remote 1   		# Remote= remote logging system "serservice_name Remote_Logging";  0=false, 1= true
-log_address 239.192.1.1 # Remote multicast address to send logs
-log_port 55554 		# port on remote machine to connect to
+log_address 239.192.1.2 # Remote multicast address to send logs
+log_port 5000 		# port on remote machine to connect to
 log_append_time 0       # append seconds since epoch to filename; 0=false, 1= true
 log_split_files 1	# seperate output and error log files (named x.o and x.e)
 
@@ -46,8 +46,8 @@ clt_dlr_socket_timeout 500	#
 inpoll_timeout 50      		# keep these short!
 outpoll_timeout 50  		# keep these short!
 command_timeout 2000		#
-multicast_port 55554		#
-multicast_address 239.192.1.1	#
+mon_port 5000			#
+mon_address 239.192.1.3		#
 
 ##### Tools To Add #####
 Tools_File configfiles/Dummy/ToolsConfig	# list of tools to run and their config files

--- a/configfiles/template/ToolChainConfig
+++ b/configfiles/template/ToolChainConfig
@@ -18,8 +18,8 @@ log_interactive 1	 # Interactive=cout; 0=false, 1= true
 log_local 0 		 # Local = local file log; 0=false, 1= true
 log_local_path ./log 	 # file to store logs to if local is active
 log_remote 0   		 # Remote= remote logging system "serservice_name Remote_Logging";  0=false, 1= true
-log_address 239.192.1.1  # Remote multicast address to send logs
-log_port 5001            # port on remote machine to connect to
+log_address 239.192.1.2  # Remote multicast address to send logs
+log_port 5000            # port on remote machine to connect to
 log_append_time 0	 # append seconds since epoch to filename; 0=false, 1= true
 log_split_files 0 	 # seperate output and error log files (named x.o and x.e)
 
@@ -45,8 +45,8 @@ clt_dlr_socket_timeout 500	#
 inpoll_timeout 50      		# keep these short!
 outpoll_timeout 50  		# keep these short!
 command_timeout 2000		#
-multicast_port 55554		#
-multicast_address 239.192.1.1	#
+mon_port 5000		#
+mon_address 239.192.1.3	#
 
 ##### Tools To Add #####
 Tools_File configfiles/ToolsConfig    # list of tools to run and their config files

--- a/src/DAQDataModelBase/DAQUtilities.cpp
+++ b/src/DAQDataModelBase/DAQUtilities.cpp
@@ -119,10 +119,11 @@ int DAQUtilities::UpdateConnections(std::string ServiceName, zmq::socket_t* sock
     if(port=="" && port_name=="") service->Get("remote_port",remote_port);
     else if(port_name!="") service->Get(port_name, remote_port);
     if(remote_port==""){
-     delete service;
-     service=0;
-     continue;	  
+      delete service;
+      service=0;
+      continue;
     }
+    //printf("updateconnections checking if service '%s' is interested in client '%s' on port '%s'\n",ServiceName.c_str(), type.c_str(),remote_port.c_str());
   
     std::string tmp=ip + ":" + remote_port;
     
@@ -162,7 +163,7 @@ DAQThread_args* DAQUtilities::CreateThread(std::string ThreadName,  void (*func)
   }
   
   return args;
-}                    
+}
 
 void *DAQUtilities::String_Thread(void *arg){
   
@@ -189,11 +190,11 @@ void *DAQUtilities::String_Thread(void *arg){
       zmq::poll(&initems[0], 1, 0);
       
       if ((initems[0].revents & ZMQ_POLLIN)){
-	
-	zmq::message_t message;
-	IThread.recv(&message);
-	command=std::string(static_cast<char *>(message.data()));
-  	
+        
+        zmq::message_t message;
+        IThread.recv(&message);
+        command=std::string(static_cast<char *>(message.data()));
+          
       }
       
       args->func_with_string(command);

--- a/src/DAQLogging/DAQLogging.cpp
+++ b/src/DAQLogging/DAQLogging.cpp
@@ -342,7 +342,6 @@ src/DAQLogging/DAQLogging.{h,cpp} -nw
   
   bzero((char *)&addr, sizeof(addr));
   addr.sin_family = AF_INET;
-  addr.sin_addr.s_addr = htonl(INADDR_ANY);
   addr.sin_port = htons(log_port);
   addrlen = sizeof(addr);
   

--- a/src/ServiceDiscovery/ServiceDiscovery.cpp
+++ b/src/ServiceDiscovery/ServiceDiscovery.cpp
@@ -4,25 +4,25 @@ using namespace ToolFramework;
 
 
 ServiceDiscovery::ServiceDiscovery(bool Send, bool Receive, int remoteport, std::string address, int multicastport, zmq::context_t * incontext, boost::uuids::uuid UUID, std::string service, int pubsec, int kicksec){
-
+  
   std::vector<std::string> in_address;
   std::vector<int> in_multicastport;
-
+  
   in_address.push_back(address);
   in_multicastport.push_back(multicastport);
-
+  
   Init(Send, Receive, remoteport, in_address, in_multicastport, incontext, UUID, service, pubsec, kicksec);
-
+  
 }
 
 ServiceDiscovery::ServiceDiscovery(bool Send, bool Receive, int remoteport, std::vector<std::string> address, std::vector<int> multicastport, zmq::context_t * incontext, boost::uuids::uuid UUID, std::string service, int pubsec, int kicksec){
   Init(Send, Receive, remoteport, address, multicastport, incontext, UUID, service, pubsec, kicksec);
- 
+  
 }
 
 void ServiceDiscovery::Init(bool Send, bool Receive, int remoteport, std::vector<std::string> address, std::vector<int> multicastport, zmq::context_t * incontext, boost::uuids::uuid UUID, std::string service, int pubsec, int kicksec){
- 
-    
+  
+  
   m_UUID=UUID;
   context=incontext;
   m_multicastport=multicastport;
@@ -31,12 +31,12 @@ void ServiceDiscovery::Init(bool Send, bool Receive, int remoteport, std::vector
   m_remoteport=remoteport;
   m_send=Send;
   m_receive=Receive;
-
-  args= new thread_args(m_UUID, context, m_multicastaddress, m_multicastport, m_service, m_remoteport, pubsec, kicksec);
-
-    if (Receive) pthread_create (&thread[0], NULL, ServiceDiscovery::MulticastListenThread, args);
   
-    if (Send) pthread_create (&thread[1], NULL, ServiceDiscovery::MulticastPublishThread, args);
+  args= new thread_args(m_UUID, context, m_multicastaddress, m_multicastport, m_service, m_remoteport, pubsec, kicksec);
+  
+  if (Receive) pthread_create (&thread[0], NULL, ServiceDiscovery::MulticastListenThread, args);
+  
+  if (Send) pthread_create (&thread[1], NULL, ServiceDiscovery::MulticastPublishThread, args);
   
   //sleep(2);
   
@@ -51,15 +51,15 @@ void ServiceDiscovery::Init(bool Send, bool Receive, int remoteport, std::vector
 }
 
 ServiceDiscovery::ServiceDiscovery( std::string address, int multicastport, zmq::context_t * incontext, int kicksec){
-
+  
   std::vector<std::string> in_address;
   std::vector<int> in_multicastport;
-
+  
   in_address.push_back(address);
   in_multicastport.push_back(multicastport);
-
+  
   Init(in_address, in_multicastport, incontext, kicksec);
-
+  
 }
 
 ServiceDiscovery::ServiceDiscovery( std::vector<std::string> address, std::vector<int> multicastport, zmq::context_t * incontext, int kicksec){
@@ -76,20 +76,20 @@ void ServiceDiscovery::Init( std::vector<std::string> address, std::vector<int> 
   m_UUID=boost::uuids::random_generator()();
   m_receive=true;
   m_send=false;
-
+  
   args= new thread_args(m_UUID, context, m_multicastaddress, m_multicastport, m_service, m_remoteport, 0 , kicksec);
-
+  
   pthread_create (&thread[0], NULL, ServiceDiscovery::MulticastListenThread, args);
-
+  
   //  sleep(2);
   
-
+  
 }
 
 
 void* ServiceDiscovery::MulticastPublishThread(void* arg){
-    
-
+  
+  
   thread_args* args= static_cast<thread_args*>(arg);
   zmq::context_t * context = args->context;
   boost::uuids::uuid m_UUID=args->UUID;
@@ -97,20 +97,20 @@ void* ServiceDiscovery::MulticastPublishThread(void* arg){
   int m_multicastport=args->multicastport.at(0);
   std::string m_service=args->service;
   int m_remoteport=args->remoteport;
-
+  
   long msg_id=0;
-
-  zmq::socket_t Ireceive (*context, ZMQ_PULL);      
+  
+  zmq::socket_t Ireceive (*context, ZMQ_PULL);
   int linger = 0;
   //Ireceive.setsockopt(ZMQ_IMMEDIATE, 1);
-  Ireceive.setsockopt (ZMQ_LINGER, &linger, sizeof (linger)); 
-  Ireceive.bind("inproc://ServicePublish");  
+  Ireceive.setsockopt (ZMQ_LINGER, &linger, sizeof (linger));
+  Ireceive.bind("inproc://ServicePublish");
   /// multi cast /////
   
   
   struct sockaddr_in addr;
   int addrlen, sock, cnt;
- // struct ip_mreq mreq;
+  // struct ip_mreq mreq;
   
   
   // set up socket //
@@ -119,8 +119,8 @@ void* ServiceDiscovery::MulticastPublishThread(void* arg){
   l.l_onoff  = 0;
   l.l_linger = 0;
   setsockopt(sock, SOL_SOCKET, SO_LINGER,(char *) &l, sizeof(l));
-	
-  //fcntl(sock, F_SETFL, O_NONBLOCK); 
+  
+  //fcntl(sock, F_SETFL, O_NONBLOCK);
   if (sock < 0) {
     perror("socket");
     printf("Failed to connect to multicast publish socket");
@@ -128,7 +128,6 @@ void* ServiceDiscovery::MulticastPublishThread(void* arg){
   }
   bzero((char *)&addr, sizeof(addr));
   addr.sin_family = AF_INET;
-  addr.sin_addr.s_addr = htonl(INADDR_ANY);
   addr.sin_port = htons(m_multicastport);
   addrlen = sizeof(addr);
   
@@ -137,7 +136,7 @@ void* ServiceDiscovery::MulticastPublishThread(void* arg){
   
   std::vector<Store> PubServices;
   
-  Store bb; 
+  Store bb;
   bb.Set("msg_type", "Service Discovery");
   bb.Set("msg_value",m_service);
   bb.Set("remote_port",m_remoteport);
@@ -145,7 +144,7 @@ void* ServiceDiscovery::MulticastPublishThread(void* arg){
   else bb.Set("status_query",false);
   bb.Set("uuid",boost::uuids::to_string(m_UUID));
   PubServices.push_back(bb);
-
+  
   //  Initialize poll set
   zmq::pollitem_t items [] = {
     { Ireceive, 0, ZMQ_POLLIN, 0 },
@@ -156,7 +155,7 @@ void* ServiceDiscovery::MulticastPublishThread(void* arg){
   bool running=true;
   
   while(running){
-  
+    
     try{
       zmq::poll(&items [0], 2, 1000);
     } catch(zmq::error_t& err){
@@ -164,7 +163,7 @@ void* ServiceDiscovery::MulticastPublishThread(void* arg){
       if(zmq_errno()==EINTR) continue;
       throw;
     }
-
+    
     if ((items [0].revents & ZMQ_POLLIN) && running) {
       
       zmq::message_t commands;
@@ -181,253 +180,253 @@ void* ServiceDiscovery::MulticastPublishThread(void* arg){
      
      
       if(command=="Quit"){
-	//printf("publish quitting \n");	
-	running=false;
+        //printf("publish quitting \n");
+        running=false;
       }
       else if(command=="Add"){
-	
-	Store bb; 
-	bb.Set("msg_type","Service Discovery");
-	bb.Set("msg_value",service);
-	bb.Set("remote_port",port);
-	bb.Set("status_query",statusquery);
-	bb.Set("uuid",boost::uuids::to_string(uuid));
-	PubServices.push_back(bb);
+        
+        Store bb;
+        bb.Set("msg_type","Service Discovery");
+        bb.Set("msg_value",service);
+        bb.Set("remote_port",port);
+        bb.Set("status_query",statusquery);
+        bb.Set("uuid",boost::uuids::to_string(uuid));
+        PubServices.push_back(bb);
 
       }
       else if(command=="Delete"){
-       	std::vector<Store>::iterator it;
-	for (it = PubServices.begin() ; it != PubServices.end(); ++it){
-	  //std::cout<<"d3.5 "<<*((*it)["msg_value"])<<std::endl;
-	 
-	  if((*it).Get<std::string>("msg_value")==service)break;
-	  
-	  
-	}
-	if (it!=PubServices.end())PubServices.erase(it);
-	
-	
+               std::vector<Store>::iterator it;
+        for (it = PubServices.begin() ; it != PubServices.end(); ++it){
+          //std::cout<<"d3.5 "<<*((*it)["msg_value"])<<std::endl;
+         
+          if((*it).Get<std::string>("msg_value")==service)break;
+          
+          
+        }
+        if (it!=PubServices.end())PubServices.erase(it);
+        
+        
       }
       else if(command=="PortAdd"){
-	if(PubServices.size()) PubServices.at(0).Set(service, port);     
+        if(PubServices.size()) PubServices.at(0).Set(service, port);
       }
       else if(command =="PortDelete"){
-	if(PubServices.size()) PubServices.at(0).Erase(service);     
+        if(PubServices.size()) PubServices.at(0).Erase(service);
       }
       
     }
     
     if ((items [1].revents & ZMQ_POLLOUT) && running){
       
-
+      
       for(unsigned int i=0;i<PubServices.size();i++){
-
-	//	char message[512];
-	
-	//      const char* json = "{\"uuid\":\"\",\"msg_id\":0,\"msg_time\":\"\",\"msg_type\":\"\",\"msg_value\":\"\",\"params\":{\"port\":0,\"status\":\"\"}}";
-	
-	
+        
+        //        char message[512];
+        
+        //      const char* json = "{\"uuid\":\"\",\"msg_id\":0,\"msg_time\":\"\",\"msg_type\":\"\",\"msg_value\":\"\",\"params\":{\"port\":0,\"status\":\"\"}}";
+        
+        
     
-	/*
-	  
-	  
-	  rapidjson::Document d;
-	  d.Parse(json);
-	  // d.SetObject();
-	  //["hello"] = "rapidjson"; 
-	  //   	test.SetString("My JSON Document", d.GetAllocator());
-	  //  	d.AddMember("Doc Name", test , d.GetAllocator());
-	  //	d.AddMember("uuid", tmp.str().c_str(), d.GetAllocator());
-	  // (*newDoc)["Parameters"].SetObject();
-	  
-	  msg_id++;
-	  std::stringstream tmp;
-	  tmp<<m_UUID;
-	  d["uuid"].SetString(tmp.str().c_str(), strlen(tmp.str().c_str()));
-	  std::cout<<" UUID = "<<tmp.str().c_str()<<std::endl;
-	  std::cout<<" 1d[UUID] = "<<d["uuid"].GetString()<<std::endl;
-	  d["msg_id"].SetInt(msg_id);
-	  std::cout<<" 2d[UUID] = "<<d["uuid"].GetString()<<std::endl;
-	*/
-
-
-	boost::posix_time::ptime t = boost::posix_time::microsec_clock::universal_time();
-	std::stringstream isot;
-	isot<<boost::posix_time::to_iso_extended_string(t) << "Z";
-
-	/*
-	  std::cout<<" 3d[UUID] = "<<d["uuid"].GetString()<<std::endl;
-	  d["msg_time"].SetString(isot.str().c_str(), strlen(isot.str().c_str()));;
-	  std::cout<<" 4d[UUID] = "<<d["uuid"].GetString()<<std::endl;
-	  d["msg_type"]="Service Discovery";
-	  d["msg_value"].SetString(m_service.c_str(),strlen(m_service.c_str()));
-	  
-	  std::cout<<" 5d[UUID] = "<<d["uuid"].GetString()<<std::endl;
-	*/ 
-
-	bool statusquery=false;
-	PubServices.at(i).Get("status_query",statusquery);
-	Store mm;
-
-
-	if(statusquery){
-	  
-	  zmq::socket_t StatusCheck (*context, ZMQ_REQ);
-	  //int a=12000;
-	  //StatusCheck.setsockopt(ZMQ_RCVTIMEO, a);
-	  //StatusCheck.setsockopt(ZMQ_SNDTIMEO, a);
-	  std::stringstream connection;
-	  connection<<"tcp://localhost:"<<PubServices.at(i).Get<std::string>("remote_port");
-	  // StatusCheck.setsockopt(ZMQ_IMMEDIATE, 1);
-	   StatusCheck.setsockopt (ZMQ_LINGER, &linger, sizeof (linger)); 
-	  
-	  StatusCheck.connect(connection.str().c_str());
-	
-	  zmq::pollitem_t out[]={{StatusCheck,0,ZMQ_POLLOUT,0}};  
-	  zmq::pollitem_t in[]={{StatusCheck,0,ZMQ_POLLIN,0}};
-
-	  mm.Set("msg_type","Command");
-	  mm.Set("msg_value","Status");
-	  
-	  std::string command;
-	  mm>>command;
-	  
-	  // zmq::message_t Esend(256);
-	  //std::string command="Status;
-	  mm.Delete();	
-	  
-	  zmq::message_t Esend(command.length()+1);
-	  snprintf ((char *) Esend.data(), command.length()+1 , "%s" ,command.c_str()) ;
-	  
-	  try{
-	    zmq::poll(out,1,1000);
-	  } catch(zmq::error_t& err){
-	    // ignore poll aborting due to signals
-	    if(zmq_errno()==EINTR) continue;
-	    throw;
-	  }
-	  
-	  if(out[0].revents & ZMQ_POLLOUT){
-	    StatusCheck.send(Esend);
-	    
-	    //std::cout<<"waiting for message "<<std::endl;
-	    try{
-	      zmq::poll(in,1,1000);
-	    } catch(zmq::error_t& err){
-	      // ignore poll aborting due to signals
-	      if(zmq_errno()==EINTR) continue;
-	      throw;
-	    }
-	    
-	    if(in[0].revents & ZMQ_POLLIN){
-	      zmq::message_t Ereceive;
-	      StatusCheck.recv (&Ereceive);
-	      std::istringstream ss(static_cast<char*>(Ereceive.data()));
-	      
-	      mm.JsonParser(ss.str());
-	    }
-	  }
-	}
-	/*
-	std::cout<<"received for publish "<<ss.str()<<std::endl;
-	std::cout<<" 6d[UUID] = "<<d["uuid"].GetString()<<std::endl;
-	/*  rapidjson::Document params;
-	
-	// params=d["params"].GetType();
-	std::cout<<d["params"].GetType()<<std::endl;
-	std::cout<<d["params"].IsNull()<<std::endl;
-	std::cout<<d["params"].IsFalse()<<std::endl;
-	std::cout<<d["params"].IsTrue()<<std::endl;
-	std::cout<<d["params"].IsBool()<<std::endl;
-	std::cout<<d["params"].IsObject()<<std::endl;
-	std::cout<<d["params"].IsArray()<<std::endl;
-	std::cout<<d["params"].IsNumber()<<std::endl;
-	std::cout<<d["params"].IsString()<<std::endl;
-	
-	// std::string tmpsubstring=d["params"].GetString();
-	//std::cout<<"tmpsubstring "<<tmpsubstring<<std::endl;
-	// params.Parse(tmpsubstring.c_str());
-	
-	std::cout<<"debug 1 "<<std::endl;
-	
-	params["port"].SetInt(m_multicastport);
-	params["status"].SetString(ss.str().c_str(),strlen(ss.str().c_str()));
-	
-	rapidjson::StringBuffer subbuffer;
-	rapidjson::Writer<rapidjson::StringBuffer> subwriter(subbuffer);
-	params.Accept(subwriter);
-	
-	std::string tmpbufferout=subbuffer.GetString();
-	
-	std::cout<<" substringtest "<<tmpbufferout<<std::endl;
-	
-	d["params"].SetString(tmpbufferout.c_str(), strlen(tmpbufferout.c_str()));
-	
-	for (rapidjson::Value::ConstMemberIterator itr = d["params"].MemberBegin();itr != d["params"].MemberEnd(); ++itr){
-	
-	std::cout<<itr->name.GetString()<<std::endl;//<<" : "<< itr->value<<std::endl;
-	//	if(itr->name.GetString()=="port") itr->value.SetInt(m_multicastport);
-	//if(itr->name.GetString()=="status") itr->value.SetString(ss.str().c_str(),strlen(ss.str().c_str()));
-	}
-	  */
-	  
-	  
-	  
-	  //rapidjson::Document params=d["params"];
-	  //params["port"].SetInt(m_multicastport,strlen();
-	  // rapidjson::Value& params = d["params"]; 
-	  // rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
-	  //    params.PushBack(i, allocator);
-	  
-	  // params.PushBack("key1","value1");
+        /*
+          
+          
+          rapidjson::Document d;
+          d.Parse(json);
+          // d.SetObject();
+          //["hello"] = "rapidjson";
+          //           test.SetString("My JSON Document", d.GetAllocator());
+          //          d.AddMember("Doc Name", test , d.GetAllocator());
+          //        d.AddMember("uuid", tmp.str().c_str(), d.GetAllocator());
+          // (*newDoc)["Parameters"].SetObject();
+          
+          msg_id++;
+          std::stringstream tmp;
+          tmp<<m_UUID;
+          d["uuid"].SetString(tmp.str().c_str(), strlen(tmp.str().c_str()));
+          std::cout<<" UUID = "<<tmp.str().c_str()<<std::endl;
+          std::cout<<" 1d[UUID] = "<<d["uuid"].GetString()<<std::endl;
+          d["msg_id"].SetInt(msg_id);
+          std::cout<<" 2d[UUID] = "<<d["uuid"].GetString()<<std::endl;
+        */
+        
+        
+        boost::posix_time::ptime t = boost::posix_time::microsec_clock::universal_time();
+        std::stringstream isot;
+        isot<<boost::posix_time::to_iso_extended_string(t) << "Z";
+        
+        /*
+          std::cout<<" 3d[UUID] = "<<d["uuid"].GetString()<<std::endl;
+          d["msg_time"].SetString(isot.str().c_str(), strlen(isot.str().c_str()));;
+          std::cout<<" 4d[UUID] = "<<d["uuid"].GetString()<<std::endl;
+          d["msg_type"]="Service Discovery";
+          d["msg_value"].SetString(m_service.c_str(),strlen(m_service.c_str()));
+          
+          std::cout<<" 5d[UUID] = "<<d["uuid"].GetString()<<std::endl;
+        */
+        
+        bool statusquery=false;
+        PubServices.at(i).Get("status_query",statusquery);
+        Store mm;
+        
+        
+        if(statusquery){
+          
+          zmq::socket_t StatusCheck (*context, ZMQ_REQ);
+          //int a=12000;
+          //StatusCheck.setsockopt(ZMQ_RCVTIMEO, a);
+          //StatusCheck.setsockopt(ZMQ_SNDTIMEO, a);
+          std::stringstream connection;
+          connection<<"tcp://localhost:"<<PubServices.at(i).Get<std::string>("remote_port");
+          // StatusCheck.setsockopt(ZMQ_IMMEDIATE, 1);
+           StatusCheck.setsockopt (ZMQ_LINGER, &linger, sizeof (linger));
+          
+          StatusCheck.connect(connection.str().c_str());
+          
+          zmq::pollitem_t out[]={{StatusCheck,0,ZMQ_POLLOUT,0}};
+          zmq::pollitem_t in[]={{StatusCheck,0,ZMQ_POLLIN,0}};
+          
+          mm.Set("msg_type","Command");
+          mm.Set("msg_value","Status");
+          
+          std::string command;
+          mm>>command;
+          
+          // zmq::message_t Esend(256);
+          //std::string command="Status;
+          mm.Delete();
+          
+          zmq::message_t Esend(command.length()+1);
+          snprintf ((char *) Esend.data(), command.length()+1 , "%s" ,command.c_str()) ;
+          
+          try{
+            zmq::poll(out,1,1000);
+          } catch(zmq::error_t& err){
+            // ignore poll aborting due to signals
+            if(zmq_errno()==EINTR) continue;
+            throw;
+          }
+          
+          if(out[0].revents & ZMQ_POLLOUT){
+            StatusCheck.send(Esend);
+            
+            //std::cout<<"waiting for message "<<std::endl;
+            try{
+              zmq::poll(in,1,1000);
+            } catch(zmq::error_t& err){
+              // ignore poll aborting due to signals
+              if(zmq_errno()==EINTR) continue;
+              throw;
+            }
+            
+            if(in[0].revents & ZMQ_POLLIN){
+              zmq::message_t Ereceive;
+              StatusCheck.recv (&Ereceive);
+              std::istringstream ss(static_cast<char*>(Ereceive.data()));
+              
+              mm.JsonParser(ss.str());
+            }
+          }
+        }
+        /*
+        std::cout<<"received for publish "<<ss.str()<<std::endl;
+        std::cout<<" 6d[UUID] = "<<d["uuid"].GetString()<<std::endl;
+        /*  rapidjson::Document params;
+        
+        // params=d["params"].GetType();
+        std::cout<<d["params"].GetType()<<std::endl;
+        std::cout<<d["params"].IsNull()<<std::endl;
+        std::cout<<d["params"].IsFalse()<<std::endl;
+        std::cout<<d["params"].IsTrue()<<std::endl;
+        std::cout<<d["params"].IsBool()<<std::endl;
+        std::cout<<d["params"].IsObject()<<std::endl;
+        std::cout<<d["params"].IsArray()<<std::endl;
+        std::cout<<d["params"].IsNumber()<<std::endl;
+        std::cout<<d["params"].IsString()<<std::endl;
+        
+        // std::string tmpsubstring=d["params"].GetString();
+        //std::cout<<"tmpsubstring "<<tmpsubstring<<std::endl;
+        // params.Parse(tmpsubstring.c_str());
+        
+        std::cout<<"debug 1 "<<std::endl;
+        
+        params["port"].SetInt(m_multicastport);
+        params["status"].SetString(ss.str().c_str(),strlen(ss.str().c_str()));
+        
+        rapidjson::StringBuffer subbuffer;
+        rapidjson::Writer<rapidjson::StringBuffer> subwriter(subbuffer);
+        params.Accept(subwriter);
+        
+        std::string tmpbufferout=subbuffer.GetString();
+        
+        std::cout<<" substringtest "<<tmpbufferout<<std::endl;
+        
+        d["params"].SetString(tmpbufferout.c_str(), strlen(tmpbufferout.c_str()));
+        
+        for (rapidjson::Value::ConstMemberIterator itr = d["params"].MemberBegin();itr != d["params"].MemberEnd(); ++itr){
+        
+        std::cout<<itr->name.GetString()<<std::endl;//<<" : "<< itr->value<<std::endl;
+        //        if(itr->name.GetString()=="port") itr->value.SetInt(m_multicastport);
+        //if(itr->name.GetString()=="status") itr->value.SetString(ss.str().c_str(),strlen(ss.str().c_str()));
+        }
+          */
+          
+          
+          
+          //rapidjson::Document params=d["params"];
+          //params["port"].SetInt(m_multicastport,strlen();
+          // rapidjson::Value& params = d["params"];
+          // rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
+          //    params.PushBack(i, allocator);
+          
+          // params.PushBack("key1","value1");
        //params.PushBack("key2","value2");
-	  /* 
-	     std::cout<<" d[UUID] = "<<d["uuid"].GetString()<<std::endl;
-	     
-	     rapidjson::StringBuffer buffer;
-	     rapidjson::Writer<rapidjson::StringBuffer, rapidjson::Document::EncodingType, rapidjson::ASCII<> > writer(buffer);
-	     //rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-	     d.Accept(writer);
-	     std::string hhh=buffer.GetString();
-	     std::cout<< "bufer = "<<hhh<<std::endl;
-	  */	
-  
-	  msg_id++;
-	  
-	  //	  PubServices.at(i).Set("uuid",m_UUID);
-	  PubServices.at(i).Set("msg_id",msg_id);
-	  PubServices.at(i).Set("msg_time", isot.str());
-	  // *bb["msg_type"]="Service Discovery";
-	  // bb.Set("msg_value",m_service);
-	  //bb.Set("remote_port",m_remoteport);
-	  
-	  if(statusquery && mm.Has("msg_value")) PubServices.at(i).Set("status",mm.Get<std::string>("msg_value")); 
-	  else PubServices.at(i).Set("status","N/A");
-	  std::string pubmessage;
-	  PubServices.at(i)>>pubmessage;
-	  
-	  //std::stringstream pubmessage;
-	  
-	  //pubmessage<<"{\"uuid\":\""<<m_UUID<<"\",\"msg_id\":"<<msg_id<<",\"msg_time\":\""<<isot.str()<<"\",\"msg_type\":\"Service Discovery\",\"msg_value\":\""<<m_service<<"\",\"params\":{\"port\":"<<m_remoteport<<",\"status\":\""<<ss.str()<<"\"}}";
-	  //char* message = new char[pubmessage.length()+1];
-	  //char message2[pubmessage.length()+1];
-	  
-	  //    snprintf (message, 512 , "%s" , buffer.GetString()) ;
-	  //snprintf (message, pubmessage.length()+1 , "%s" , pubmessage.c_str() ) ;
-	  
-	  //printf("sending: %s\n", pubmessage.c_str());
-	  //std::cout<<sizeof(*message)<<":"<<sizeof(message2)<<":"<<pubmessage.length()+1<<std::endl;
-	  //  cnt = sendto(sock, message, sizeof(message), 0,(struct sockaddr *) &addr, addrlen);
-	  //cnt = sendto(sock, message, sizeof(char)*pubmessage.length()+1, 0,(struct sockaddr *) &addr, addrlen);
-	  cnt = sendto(sock, pubmessage.c_str(), pubmessage.length()+1, 0,(struct sockaddr *) &addr, addrlen);
-	 
-	  //printf("sent\n");
-	    if (cnt < 0) {
-	    perror("sendto");
-	    }
-	  
-	  
- 
+          /* 
+             std::cout<<" d[UUID] = "<<d["uuid"].GetString()<<std::endl;
+             
+             rapidjson::StringBuffer buffer;
+             rapidjson::Writer<rapidjson::StringBuffer, rapidjson::Document::EncodingType, rapidjson::ASCII<> > writer(buffer);
+             //rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+             d.Accept(writer);
+             std::string hhh=buffer.GetString();
+             std::cout<< "bufer = "<<hhh<<std::endl;
+          */
+          
+          msg_id++;
+          
+          //PubServices.at(i).Set("uuid",m_UUID);
+          PubServices.at(i).Set("msg_id",msg_id);
+          PubServices.at(i).Set("msg_time", isot.str());
+          // *bb["msg_type"]="Service Discovery";
+          // bb.Set("msg_value",m_service);
+          //bb.Set("remote_port",m_remoteport);
+          
+          if(statusquery && mm.Has("msg_value")) PubServices.at(i).Set("status",mm.Get<std::string>("msg_value"));
+          else PubServices.at(i).Set("status","N/A");
+          std::string pubmessage;
+          PubServices.at(i)>>pubmessage;
+          
+          //std::stringstream pubmessage;
+          
+          //pubmessage<<"{\"uuid\":\""<<m_UUID<<"\",\"msg_id\":"<<msg_id<<",\"msg_time\":\""<<isot.str()<<"\",\"msg_type\":\"Service Discovery\",\"msg_value\":\""<<m_service<<"\",\"params\":{\"port\":"<<m_remoteport<<",\"status\":\""<<ss.str()<<"\"}}";
+          //char* message = new char[pubmessage.length()+1];
+          //char message2[pubmessage.length()+1];
+          
+          //snprintf (message, 512 , "%s" , buffer.GetString()) ;
+          //snprintf (message, pubmessage.length()+1 , "%s" , pubmessage.c_str() ) ;
+          
+          //printf("sending: %s\n", pubmessage.c_str());
+          //std::cout<<sizeof(*message)<<":"<<sizeof(message2)<<":"<<pubmessage.length()+1<<std::endl;
+          //  cnt = sendto(sock, message, sizeof(message), 0,(struct sockaddr *) &addr, addrlen);
+          //cnt = sendto(sock, message, sizeof(char)*pubmessage.length()+1, 0,(struct sockaddr *) &addr, addrlen);
+          cnt = sendto(sock, pubmessage.c_str(), pubmessage.length()+1, 0,(struct sockaddr *) &addr, addrlen);
+         
+          //printf("sent\n");
+          if (cnt < 0) {
+            perror("sendto");
+          }
+          
+          
+          
       }
       //printf("b1\n");
       sleep(args->pubsec);
@@ -440,7 +439,7 @@ void* ServiceDiscovery::MulticastPublishThread(void* arg){
   close(sock);
   Ireceive.close();
   //  printf("publish out of runnin \n");
-
+  
   pthread_exit(NULL);
   //return (NULL);
   
@@ -449,7 +448,7 @@ void* ServiceDiscovery::MulticastPublishThread(void* arg){
 
 
 void* ServiceDiscovery::MulticastListenThread(void* arg){
-
+  
   thread_args* args= static_cast<thread_args*>(arg);
   zmq::context_t * context = args->context;
  // boost::uuids::uuid m_UUID=args->UUID;
@@ -458,9 +457,11 @@ void* ServiceDiscovery::MulticastListenThread(void* arg){
   std::string m_service=args->service;
   
   zmq::socket_t Ireceive (*context, ZMQ_ROUTER);
-  Ireceive.bind("inproc://ServiceDiscovery");  
+  int linger = 0;
+  Ireceive.setsockopt (ZMQ_LINGER, &linger, sizeof (linger));
+  Ireceive.bind("inproc://ServiceDiscovery");
   
-
+  
   /*
   zmq::message_t config;
   Ireceive.recv (&config);
@@ -471,26 +472,26 @@ void* ServiceDiscovery::MulticastListenThread(void* arg){
   
   Ireceive.send(config);
   */
-
+  
   ///// multi cast /////
   
   std::vector<int> sock;
   char message[512];
   std::vector<struct sockaddr_in> addr;
   std::vector<int> addrlen;
-
+  
   std::vector<zmq::pollitem_t> items;
-
+  
   items.resize(m_multicastaddress.size()+1);
   
   //zmq::pollitem_t items[m_multicastaddress.size()+1];
- 
+  
   items.at(0).socket = Ireceive;
   items.at(0).fd = 0;
   items.at(0).events = ZMQ_POLLIN;
   items.at(0).revents = 0;
   
-
+  
   zmq::pollitem_t out[] = {
     {Ireceive, 0, ZMQ_POLLOUT, 0}
   };
@@ -505,34 +506,34 @@ void* ServiceDiscovery::MulticastListenThread(void* arg){
     sock.emplace_back(socket(AF_INET, SOCK_DGRAM, 0));
     addrlen.emplace_back();
     addr.emplace_back();
-
+    
     int a =1;
     setsockopt(sock.at(i), SOL_SOCKET, SO_REUSEADDR, &a, sizeof(int));
-    //fcntl(sock, F_SETFL, O_NONBLOCK); 
+    //fcntl(sock, F_SETFL, O_NONBLOCK);
     if (sock.at(i) < 0) {
       perror("socket");
       exit(1);
     }
     bzero((char *)&addr.at(i), sizeof(addr.at(i)));
     addr.at(i).sin_family = AF_INET;
-    addr.at(i).sin_addr.s_addr = htonl(INADDR_ANY);
+    inet_aton(m_multicastaddress.at(i).c_str(), &addr.at(i).sin_addr);
     addr.at(i).sin_port = htons(m_multicastport.at(i));
     addrlen.at(i) = sizeof(addr.at(i));
     
     // receive //
-    if (bind(sock.at(i), (struct sockaddr *) &addr.at(i), sizeof(addr.at(i))) < 0) {        
+    if (bind(sock.at(i), (struct sockaddr *) &addr.at(i), sizeof(addr.at(i))) < 0) {
       perror("bind");
       printf("Failed to bind to multicast listen socket");
       exit(1);
-    }    
-    mreq.imr_multiaddr.s_addr = inet_addr(m_multicastaddress.at(i).c_str());         
-    mreq.imr_interface.s_addr = htonl(INADDR_ANY);         
+    }
+    mreq.imr_multiaddr.s_addr = inet_addr(m_multicastaddress.at(i).c_str());
+    mreq.imr_interface.s_addr = htonl(INADDR_ANY);
     if (setsockopt(sock.at(i), IPPROTO_IP, IP_ADD_MEMBERSHIP,&mreq, sizeof(mreq)) < 0) {
       perror("setsockopt mreq");
       printf("Failed to join multicast group listen thread");
       exit(1);
-    }         
-  
+    }
+    
     
     items.at(i+1).socket = 0;
     items.at(i+1).fd = sock.at(i);
@@ -561,90 +562,90 @@ void* ServiceDiscovery::MulticastListenThread(void* arg){
     
     for(size_t i =0; i < sock.size(); i++){    
       if ((items.at(i+1).revents & ZMQ_POLLIN) && running) {
-	
-	
-	cnt = recvfrom(sock.at(i), message, sizeof(message), 0, (struct sockaddr *) &addr.at(i), (socklen_t*) &addrlen.at(i));
-	if ((cnt > 0) && (message[0]=='{') ) {
-	  //perror("recvfrom");
-	  // exit(1);
-	  //	break;
-	  //} 
-	  //else if (cnt > 0){
-	  //printf("%s: message = \"%s\"\n", inet_ntoa(addr.at(i).sin_addr), message);
-	  
-	  //if(message[0]!='[') break;
-	  
-	  Store* newservice= new Store();
-	  newservice->Set("ip",inet_ntoa(addr.at(i).sin_addr));
-	  newservice->JsonParser(message);
-	  
-	  std::string uuid;
-	  newservice->Get("uuid",uuid);
-	  if(RemoteServices.count(uuid)) delete RemoteServices[uuid];
-	//std::cout<<uuid<<std::endl;
-	  RemoteServices[uuid]=newservice;
-	  
-	  
-	  //	std::cout<<" SD RemoteServices size = " << RemoteServices.size()<<std::endl;
-	  
-	  // }
-	  
-	  
-	  
-	}
+        
+        cnt = recvfrom(sock.at(i), message, sizeof(message), 0, (struct sockaddr *) &addr.at(i),  (socklen_t*)&addrlen.at(i));
+        
+        if ((cnt > 0) && (message[0]=='{') ) {
+          //perror("recvfrom");
+          // exit(1);
+          //        break;
+          //} 
+          //else if (cnt > 0){
+          //printf("%s: message = \"%s\"\n", inet_ntoa(addr.at(i).sin_addr), message);
+          
+          //if(message[0]!='[') break;
+          
+          Store* newservice= new Store();
+          newservice->Set("ip",inet_ntoa(addr.at(i).sin_addr));
+          newservice->JsonParser(message);
+          
+          std::string uuid;
+          newservice->Get("uuid",uuid);
+          if(RemoteServices.count(uuid)) delete RemoteServices[uuid];
+        //std::cout<<uuid<<std::endl;
+          RemoteServices[uuid]=newservice;
+          
+          
+          //        std::cout<<" SD RemoteServices size = " << RemoteServices.size()<<std::endl;
+          
+          // }
+          
+          
+          
+        }
       }
       
-      //	std::cout<<" SD RemoteServices size = " << RemoteServices.size()<<std::endl;
+      //        std::cout<<" SD RemoteServices size = " << RemoteServices.size()<<std::endl;
       
       std::vector<std::string> erase_list;
       
       for (std::map<std::string,Store*>::iterator it=RemoteServices.begin(); it!=RemoteServices.end(); ++it){ 
-	//  if(*(it->second)[msg_time]==) delete;
-	
-	//std::string date_1 = "2014-08-15 10:12:10";
-	//std::string now = "2014-08-15 16:40:02";
-	
-	std::string msg_time_orig;
-	std::string msg_time_after;
-	it->second->Get("msg_time",msg_time_orig);
-	
-	//std::cout<<" time orig ="<<msg_time_orig<<std::endl;
-	
-	for(std::string::size_type i = 0; i < msg_time_orig.size(); ++i) {
-	  if(msg_time_orig[i]!='-' && msg_time_orig[i]!=':') msg_time_after+=msg_time_orig[i];
-	}
-	//std::cout<<" time after ="<<msg_time_after<<std::endl;
-	
-	boost::posix_time::ptime t1 = boost::posix_time::microsec_clock::universal_time();
-	
-	//std::stringstream isot;
-	//isot<<boost::posix_time::to_iso_extended_string(t) << "Z";
-	
-	boost::posix_time::ptime t2(boost::posix_time::from_iso_string(msg_time_after));
-	
-	//std::cout << "t1: " << t1 << std::endl;
-	//std::cout << "t2: " << t2 << std::endl;
-	
-	boost::posix_time::time_duration td = t2 - t1;
-	
-	tm td_tm = to_tm(td);
-	//std::cout << boost::posix_time::to_iso_string(td) << std::endl;
-	// std::cout<<"seconds = "<<td_tm.tm_sec<<std::endl; 
-	// std::cout<<"mins = "<<td_tm.tm_min<<std::endl; 
-	if(((td_tm.tm_min*60)+td_tm.tm_sec)>args->kicksec){
-	  erase_list.push_back(it->first);
-	  //	delete it->second;
-	  //it->second=0;
-	  //RemoteServices.erase(it->first);
-	  
-	}
-	//std::cout<< "uuid = "<<it->first<<std::endl;
+        //  if(*(it->second)[msg_time]==) delete;
+        
+        //std::string date_1 = "2014-08-15 10:12:10";
+        //std::string now = "2014-08-15 16:40:02";
+        
+        std::string msg_time_orig;
+        std::string msg_time_after;
+        it->second->Get("msg_time",msg_time_orig);
+        
+        //std::cout<<" time orig ="<<msg_time_orig<<std::endl;
+        
+        for(std::string::size_type i = 0; i < msg_time_orig.size(); ++i) {
+          if(msg_time_orig[i]!='-' && msg_time_orig[i]!=':') msg_time_after+=msg_time_orig[i];
+        }
+        //std::cout<<" time after ="<<msg_time_after<<std::endl;
+        
+        boost::posix_time::ptime t1 = boost::posix_time::microsec_clock::universal_time();
+        
+        //std::stringstream isot;
+        //isot<<boost::posix_time::to_iso_extended_string(t) << "Z";
+        
+        boost::posix_time::ptime t2(boost::posix_time::from_iso_string(msg_time_after));
+        
+        //std::cout << "t1: " << t1 << std::endl;
+        //std::cout << "t2: " << t2 << std::endl;
+        
+        boost::posix_time::time_duration td = t2 - t1;
+        
+        tm td_tm = to_tm(td);
+        //std::cout << boost::posix_time::to_iso_string(td) << std::endl;
+        // std::cout<<"seconds = "<<td_tm.tm_sec<<std::endl;
+        // std::cout<<"mins = "<<td_tm.tm_min<<std::endl;
+        if(((td_tm.tm_min*60)+td_tm.tm_sec)>args->kicksec){
+          erase_list.push_back(it->first);
+          //        delete it->second;
+          //it->second=0;
+          //RemoteServices.erase(it->first);
+          
+        }
+        //std::cout<< "uuid = "<<it->first<<std::endl;
       }
       
       for(unsigned int i=0;i<erase_list.size();i++){
-	delete RemoteServices[erase_list.at(i)];
-	RemoteServices[erase_list.at(i)]=0;
-	RemoteServices.erase(erase_list.at(i));
+        delete RemoteServices[erase_list.at(i)];
+        RemoteServices[erase_list.at(i)]=0;
+        RemoteServices.erase(erase_list.at(i));
       }
       erase_list.clear();
       
@@ -660,144 +661,144 @@ void* ServiceDiscovery::MulticastListenThread(void* arg){
       zmq::message_t comm;
       
       if(Ireceive.recv(&comm)){
-	
-	std::istringstream iss(static_cast<char*>(comm.data()));
-	std::string arg1="";
-	std::string arg2="";
-	
-	iss>>arg1;
-	
-	if(arg1=="All"){
-	  
-	  //printf("d2\n");
-	  //zmq::message_t sizem(512);
-	  int size= RemoteServices.size();
-	  zmq::message_t sizem(sizeof size);
-	  
-	  snprintf ((char *) sizem.data(), sizeof size , "%d" ,size) ;
-	  
-	  //	   zmq::poll(out,1,1000);
-	  
-	  // if (out[0].revents & ZMQ_POLLOUT){ 
-	  //std::cout<<"SD sent size="<<size<<std::endl;
-	  //std::cout<<"SD sent message size="<<sizeof(sizem.data())<<std::endl;
-	  
-	  if(size==0) Ireceive.send(sizem);
-	  else Ireceive.send(sizem,ZMQ_SNDMORE);	    
-	  
-	  
-	  for (std::map<std::string,Store*>::iterator it=RemoteServices.begin(); it!=RemoteServices.end(); ){
-	    
-	    std::string service;
-	    *(it->second)>>service;
-	    zmq::message_t send(service.length()+1);
-	    snprintf ((char *) send.data(), service.length()+1 , "%s" ,service.c_str()) ;
-	    
-	    //	       zmq::poll(out,1,1000);
-	    
-	    //	       if (out[0].revents & ZMQ_POLLOUT){
-	    it++;
-	    if(it!=RemoteServices.end()){
-	      Ireceive.send(send,ZMQ_SNDMORE);
-	      //std::cout<<"SD sent a message"<<std::endl;
-	      
-	    }
-	    else {
-	      Ireceive.send(send);
-	      //std::cout<<"SD sent final message"<<std::endl;
-	    }
-	    
-	    // }
-	    // else {
-	    // break;
-	    // }
-	    
-	  }
-	  // }
-	  
-	}
-	
-	
-	if(arg1=="Service"){
-	  
-	  iss>>arg1>>arg2;
-	  
-	  for (std::map<std::string,Store*>::iterator it=RemoteServices.begin(); it!=RemoteServices.end(); ++it){
-	    
-	    std::string test;
-	    it->second->Get("service",test);
-	    
-	    if(arg2==test){
-	      
-	      std::string service;
-	      *(it->second)>>service;
-	      zmq::message_t send(service.length()+1);
-	      snprintf ((char *) send.data(), service.length()+1 , "%s" ,service.c_str()) ;
-	
-	      try{
-	        zmq::poll(out,1,1000);
-	      } catch(zmq::error_t& err){
-	        // ignore poll aborting due to signals
-	        if(zmq_errno()==EINTR) continue;
-	        throw;
-	      }
-
-	      
-	      if(out[0].revents & ZMQ_POLLOUT) Ireceive.send(send);	    
-	    }
-	  }
-	  
-	}
-	
-	
-	
-	if(arg1=="UUID"){
-	  
-	  iss>>arg1>>arg2;
-	  
-	  for (std::map<std::string,Store*>::iterator it=RemoteServices.begin(); it!=RemoteServices.end(); ++it){
-	    
-	    
-	    std::string test;
-	    it->second->Get("uuid",test);
-	    
-	    if(arg2==test){
-	      
-	      std::string service;
-	      *(it->second)>>service;
-	      zmq::message_t send(service.length()+1);
-	      snprintf ((char *) send.data(), service.length()+1 , "%s" ,service.c_str()) ;
-	
-	      try{
-	        zmq::poll(out,1,1000);
-	      } catch(zmq::error_t& err){
-	        // ignore poll aborting due to signals
-	        if(zmq_errno()==EINTR) continue;
-	        throw;
-	      }
-	      
-	      if(out[0].revents & ZMQ_POLLOUT) Ireceive.send(send);	    
-	    }
-	  }
-	  
-	}
-	
-	if(arg1=="Quit"){
-	  
-	  running=false;
-	  //printf("quitting listening \n");	
-	}
-	
-	
         
-	
-	/*
-	  std::string tmp="0";
-	  zmq::message_t send(tmp.length()+1);
-	  snprintf ((char *) send.data(), tmp.length()+1 , "%s" ,tmp.c_str()) ;
-	  Ireceive.send(send);
-	  //printf("sent \n");
-	  */
+        std::istringstream iss(static_cast<char*>(comm.data()));
+        std::string arg1="";
+        std::string arg2="";
+        
+        iss>>arg1;
+        
+        if(arg1=="All"){
+          
+          //printf("d2\n");
+          //zmq::message_t sizem(512);
+          int size= RemoteServices.size();
+          zmq::message_t sizem(sizeof size);
+          
+          snprintf ((char *) sizem.data(), sizeof size , "%d" ,size) ;
+          
+          //           zmq::poll(out,1,1000);
+          
+          // if (out[0].revents & ZMQ_POLLOUT){ 
+          //std::cout<<"SD sent size="<<size<<std::endl;
+          //std::cout<<"SD sent message size="<<sizeof(sizem.data())<<std::endl;
+          
+          if(size==0) Ireceive.send(sizem);
+          else Ireceive.send(sizem,ZMQ_SNDMORE);
+          
+          
+          for (std::map<std::string,Store*>::iterator it=RemoteServices.begin(); it!=RemoteServices.end(); ){
+            
+            std::string service;
+            *(it->second)>>service;
+            zmq::message_t send(service.length()+1);
+            snprintf ((char *) send.data(), service.length()+1 , "%s" ,service.c_str()) ;
+            
+            //               zmq::poll(out,1,1000);
+            
+            //               if (out[0].revents & ZMQ_POLLOUT){
+            it++;
+            if(it!=RemoteServices.end()){
+              Ireceive.send(send,ZMQ_SNDMORE);
+              //std::cout<<"SD sent a message"<<std::endl;
+              
+            }
+            else {
+              Ireceive.send(send);
+              //std::cout<<"SD sent final message"<<std::endl;
+            }
+            
+            // }
+            // else {
+            // break;
+            // }
+            
+          }
+          // }
+          
+        }
+        
+        
+        if(arg1=="Service"){
+          
+          iss>>arg1>>arg2;
+          
+          for (std::map<std::string,Store*>::iterator it=RemoteServices.begin(); it!=RemoteServices.end(); ++it){
+            
+            std::string test;
+            it->second->Get("service",test);
+            
+            if(arg2==test){
+              
+              std::string service;
+              *(it->second)>>service;
+              zmq::message_t send(service.length()+1);
+              snprintf ((char *) send.data(), service.length()+1 , "%s" ,service.c_str()) ;
+        
+              try{
+                zmq::poll(out,1,1000);
+              } catch(zmq::error_t& err){
+                // ignore poll aborting due to signals
+                if(zmq_errno()==EINTR) continue;
+                throw;
+              }
+              
+              
+              if(out[0].revents & ZMQ_POLLOUT) Ireceive.send(send);
+            }
+          }
+          
+        }
+        
+        
+        
+        if(arg1=="UUID"){
+          
+          iss>>arg1>>arg2;
+          
+          for (std::map<std::string,Store*>::iterator it=RemoteServices.begin(); it!=RemoteServices.end(); ++it){
+            
+            
+            std::string test;
+            it->second->Get("uuid",test);
+            
+            if(arg2==test){
+              
+              std::string service;
+              *(it->second)>>service;
+              zmq::message_t send(service.length()+1);
+              snprintf ((char *) send.data(), service.length()+1 , "%s" ,service.c_str()) ;
+              
+              try{
+                zmq::poll(out,1,1000);
+              } catch(zmq::error_t& err){
+                // ignore poll aborting due to signals
+                if(zmq_errno()==EINTR) continue;
+                throw;
+              }
+              
+              if(out[0].revents & ZMQ_POLLOUT) Ireceive.send(send);
+            }
+          }
+          
+        }
+        
+        if(arg1=="Quit"){
+          
+          running=false;
+          //printf("quitting listening \n");
+        }
+        
+        
+        
+        
+        /*
+          std::string tmp="0";
+          zmq::message_t send(tmp.length()+1);
+          snprintf ((char *) send.data(), tmp.length()+1 , "%s" ,tmp.c_str()) ;
+          Ireceive.send(send);
+          //printf("sent \n");
+          */
       }
       
     }
@@ -805,16 +806,16 @@ void* ServiceDiscovery::MulticastListenThread(void* arg){
     
   }
   
-for (std::map<std::string,Store*>::iterator it=RemoteServices.begin(); it!=RemoteServices.end(); ++it){
-  delete it->second;
-  it->second=0;
+  for (std::map<std::string,Store*>::iterator it=RemoteServices.begin(); it!=RemoteServices.end(); ++it){
+    delete it->second;
+    it->second=0;
+    
+  }
+  RemoteServices.clear();
+  //printf("exiting sd listen thread \n");
+  pthread_exit(NULL);
+  //return (NULL);
   
- }
- RemoteServices.clear();
- //printf("exiting sd listen thread \n");
- pthread_exit(NULL);
- //return (NULL);
- 
 }
 
 
@@ -822,7 +823,7 @@ for (std::map<std::string,Store*>::iterator it=RemoteServices.begin(); it!=Remot
 ServiceDiscovery::~ServiceDiscovery(){
   
   //printf("in sd destructor \n");
-  sleep(1);  
+  sleep(1);
   //printf("finnish sleep \n");
   
   // kill publish thread
@@ -831,6 +832,8 @@ ServiceDiscovery::~ServiceDiscovery(){
   if (m_send){
     //printf("in sd send kill \n");
     zmq::socket_t ServicePublish (*context, ZMQ_PUSH);
+    int linger = 0;
+    ServicePublish.setsockopt (ZMQ_LINGER, &linger, sizeof (linger));
     //int a=120000;
     //ServicePublish.setsockopt(ZMQ_RCVTIMEO, a);
     //ServicePublish.setsockopt(ZMQ_SNDTIMEO, a);
@@ -860,9 +863,11 @@ ServiceDiscovery::~ServiceDiscovery(){
   if(m_receive){
     //printf("in sd receive kill \n");
     zmq::socket_t ServiceDiscovery (*context, ZMQ_DEALER);
+    int linger=0;
+    ServiceDiscovery.setsockopt (ZMQ_LINGER, &linger, sizeof (linger));
     //  int a=60000;
     //ServiceDiscovery.setsockopt(ZMQ_RCVTIMEO, a);
-    //ServiceDiscovery.setsockopt(ZMQ_SNDTIMEO, a);    
+    //ServiceDiscovery.setsockopt(ZMQ_SNDTIMEO, a);
     ServiceDiscovery.connect("inproc://ServiceDiscovery");
     
     
@@ -889,7 +894,7 @@ ServiceDiscovery::~ServiceDiscovery(){
     //printf("finnish Set args=0 \n");
   }
   //printf("deleted args \n");
-
+  
   
   //printf("finnish sd destructor \n");
 }

--- a/src/ServiceDiscovery/ServiceDiscovery.cpp
+++ b/src/ServiceDiscovery/ServiceDiscovery.cpp
@@ -177,8 +177,8 @@ void* ServiceDiscovery::MulticastPublishThread(void* arg){
       bool statusquery;
       
       tmp>>command>>service>>uuid>>port>>statusquery;
-     
-     
+      
+      //printf("SD publish thread got request command %s\n",command.c_str());
       if(command=="Quit"){
         //printf("publish quitting \n");
         running=false;
@@ -192,6 +192,7 @@ void* ServiceDiscovery::MulticastPublishThread(void* arg){
         bb.Set("status_query",statusquery);
         bb.Set("uuid",boost::uuids::to_string(uuid));
         PubServices.push_back(bb);
+        //printf("SD publish thread Adding service %s\n", service.c_str());
 
       }
       else if(command=="Delete"){
@@ -209,11 +210,13 @@ void* ServiceDiscovery::MulticastPublishThread(void* arg){
       }
       else if(command=="PortAdd"){
         if(PubServices.size()) PubServices.at(0).Set(service, port);
+        //printf("SD publish thread %s adding port %d for service %s (# services: %d)\n",(PubServices.empty() ? "not" : "\b"), port, service.c_str(), PubServices.size());
       }
       else if(command =="PortDelete"){
         if(PubServices.size()) PubServices.at(0).Erase(service);
       }
       
+      continue;
     }
     
     if ((items [1].revents & ZMQ_POLLOUT) && running){
@@ -571,7 +574,7 @@ void* ServiceDiscovery::MulticastListenThread(void* arg){
           //        break;
           //} 
           //else if (cnt > 0){
-          //printf("%s: message = \"%s\"\n", inet_ntoa(addr.at(i).sin_addr), message);
+          //printf("SD receive from %s: message = \"%s\"\n", inet_ntoa(addr.at(i).sin_addr), message);
           
           //if(message[0]!='[') break;
           

--- a/src/ServiceDiscovery/Services.cpp
+++ b/src/ServiceDiscovery/Services.cpp
@@ -2,6 +2,10 @@
 
 using namespace ToolFramework;
 
+namespace {
+  const uint32_t MAX_UDP_PACKET_SIZE = 655355;
+}
+
 Services::Services(){
   m_context=0;
   m_dbname="";
@@ -33,7 +37,7 @@ bool Services::Init(Store &m_variables, zmq::context_t* context_in, SlowControlC
   m_variables.Get("alerts_receive", alerts_receive);
   m_variables.Get("alert_receive_port", alert_receive_port);
   m_variables.Get("sc_port", sc_port);
-    
+  
   sc_vars->InitThreadedReceiver(m_context, sc_port, 100, new_service, alert_receive_port, alerts_receive, alert_send_port, alerts_send);
   m_backend_client.SetUp(m_context);
   
@@ -50,7 +54,7 @@ bool Services::Init(Store &m_variables, zmq::context_t* context_in, SlowControlC
   // so we need to wait for the middleman to receive one & connect before we can communicate with it.
   int pub_period=5;
   m_variables.Get("service_publish_sec",pub_period);
-  Ready(pub_period*1000);
+  Ready(pub_period*3000); // wait for 3x SD publish period. Trial and error: Why so long needed?
   
   return true;
 }
@@ -70,23 +74,23 @@ bool Services::SendAlarm(const std::string& message, unsigned int level, const s
   // we only handle 2 levels of alarm: critical (level 0) and normal (level!=0).
   if(level>0) level=1;
   
-  std::string cmd_string = "{\"time\":"+std::to_string(timestamp)
+  std::string cmd_string = "{\"time\":\""+TimeStringFromUnixMs(timestamp)+"\""
                          + ",\"device\":\""+name+"\""
                          + ",\"level\":"+std::to_string(level)
-                         + ",\"message\":\"" + message + "\"}";
+                         + ",\"alarm\":\"" + message + "\"}";
   
   std::string err="";
   
   // send the alarm on the pub socket
-  bool ok = m_backend_client.SendCommand("W_ALARM", cmd_string, (std::vector<std::string>*)nullptr, &timeout,  &err);
+  bool ok = m_backend_client.SendCommand("W_ALARM", cmd_string, (std::vector<std::string>*)nullptr, &timeout, &err);
   if(!ok){
     std::clog<<"SendAlarm error: "<<err<<std::endl;
   }
   // SendAlarm returns nothing
   
   // also record it to the logging socket
-  cmd_string = std::string{"{ \"topic\":\"LOGGING\""}
-             + ",\"time\":"+std::to_string(timestamp)
+  cmd_string = std::string{"{\"topic\":\"LOGGING\""}
+             + ",\"time\":\""+TimeStringFromUnixMs(timestamp)+"\""
              + ",\"device\":\""+name+"\""
              + ",\"severity\":0"
              + ",\"message\":\"" + message + "\"}";
@@ -107,10 +111,10 @@ bool Services::SendCalibrationData(const std::string& json_data, const std::stri
   
   const std::string& c_name = (name=="") ? m_name : name;
   
-  std::string cmd_string = "{ \"time\":"+std::to_string(timestamp)
+  std::string cmd_string = "{ \"time\":\""+TimeStringFromUnixMs(timestamp)+"\""
                          + ", \"name\":\""+ c_name +"\""
                          + ", \"description\":\""+ description+"\""
-                         + ", \"data\":\""+ json_data +"\" }";
+                         + ", \"data\":"+ json_data +" }";
   
   std::string err="";
   std::string response="";
@@ -125,18 +129,14 @@ bool Services::SendCalibrationData(const std::string& json_data, const std::stri
     return false;
   }
   
-  // response is json with the version number of the created config entry
-  // e.g. '{"version":3}'. check this is what we got, as validation.
-  Store tmp;
-  tmp.JsonParser(response);
-  int tmp_version;
-  bool ok = tmp.Get("version",tmp_version);
+  // response is the version number of the created config entry
   if(version){
-    *version = tmp_version;
-  }
-  if(!ok){
-    std::clog<<"SendCalibrationData error: invalid response: '"<<response<<"'"<<std::endl;
-    return false;
+    try {
+      *version = stoull(response);
+    } catch(std::exception& e){
+      std::clog<<"SendCalibrationData error: invalid response: '"<<response<<"'"<<std::endl;
+      return false;
+    }
   }
   
   return true;
@@ -151,11 +151,11 @@ bool Services::SendDeviceConfig(const std::string& json_data, const std::string&
   
   const std::string& name = (device=="") ? m_name : device;
   
-  std::string cmd_string = "{ \"time\":"+std::to_string(timestamp)
+  std::string cmd_string = "{ \"time\":\""+TimeStringFromUnixMs(timestamp)+"\""
                          + ", \"device\":\""+ name+"\""
                          + ", \"author\":\""+ author+"\""
                          + ", \"description\":\""+ description+"\""
-                         + ", \"data\":\""+ json_data +"\" }";
+                         + ", \"data\":"+ json_data +" }";
   
   std::string response="";
   std::string err="";
@@ -170,18 +170,14 @@ bool Services::SendDeviceConfig(const std::string& json_data, const std::string&
     return false;
   }
   
-  // response is json with the version number of the created config entry
-  // e.g. '{"version":3}'. check this is what we got, as validation.
-  Store tmp;
-  tmp.JsonParser(response);
-  int tmp_version;
-  bool ok = tmp.Get("version",tmp_version);
+  // response is the version number of the created config entry
   if(version){
-    *version = tmp_version;
-  }
-  if(!ok){
-    std::clog<<"SendDeviceConfig error: invalid response: '"<<response<<"'"<<std::endl;
-    return false;
+    try {
+      *version = stoull(response);
+    } catch(std::exception& e){
+      std::clog<<"SendDeviceConfig error: invalid response: '"<<response<<"'"<<std::endl;
+      return false;
+    }
   }
   
   return true;
@@ -194,11 +190,11 @@ bool Services::SendRunConfig(const std::string& json_data, const std::string& na
   
   if(version) *version=-1;
   
-  std::string cmd_string = "{ \"time\":"+std::to_string(timestamp)
+  std::string cmd_string = "{ \"time\":\""+TimeStringFromUnixMs(timestamp)+"\""
                          + ", \"name\":\""+ name+"\""
                          + ", \"author\":\""+ author+"\""
                          + ", \"description\":\""+ description+"\""
-                         + ", \"data\":\""+ json_data +"\" }";
+                         + ", \"data\":"+ json_data +" }";
   
   std::string response="";
   std::string err="";
@@ -213,18 +209,14 @@ bool Services::SendRunConfig(const std::string& json_data, const std::string& na
     return false;
   }
   
-  // response is json with the version number of the created config entry
-  // e.g. '{"version":3}'. check this is what we got, as validation.
-  Store tmp;
-  tmp.JsonParser(response);
-  int tmp_version;
-  bool ok = tmp.Get("version",tmp_version);
+  // response is the version number of the created config entry
   if(version){
-    *version = tmp_version;
-  }
-  if(!ok){
-    std::clog<<"SendRunConfig error: invalid response: '"<<response<<"'"<<std::endl;
-    return false;
+    try {
+      *version = stoull(response);
+    } catch(std::exception& e){
+      std::clog<<"SendRunConfig error: invalid response: '"<<response<<"'"<<std::endl;
+      return false;
+    }
   }
   
   return true;
@@ -233,13 +225,13 @@ bool Services::SendRunConfig(const std::string& json_data, const std::string& na
 
 // ««-------------- ≪ °◇◆◇° ≫ --------------»»
 
-bool Services::SendROOTplotZmq(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, const unsigned int keep_until, int* version, const uint64_t timestamp, const unsigned int timeout){
+bool Services::SendROOTplotZmq(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, int* version, const uint64_t timestamp, const unsigned int lifetime, const unsigned int timeout){
   
-  std::string cmd_string = "{ \"time\":"+std::to_string(timestamp)
+  std::string cmd_string = "{ \"time\":\""+TimeStringFromUnixMs(timestamp)+"\""
                          + ", \"name\":\""+ plot_name +"\""
                          + ", \"draw_options\":\""+ draw_options +"\""
-                         + ", \"data\":\""+ json_data+"\""
-                         + ", \"keep_until\":"+std::to_string(keep_until)+" }"; // FIXME modify DB as per retention
+                         + ", \"lifetime\":"+std::to_string(lifetime)
+                         + ", \"data\":"+ json_data+" }";
   
   std::string err="";
   std::string response="";
@@ -254,18 +246,14 @@ bool Services::SendROOTplotZmq(const std::string& plot_name, const std::string& 
     return false;
   }
   
-  // response is json with the version number of the created plot entry
-  // e.g. '{"version":3}'. check this is what we got, as validation.
-  Store tmp;
-  tmp.JsonParser(response);
-  int tmp_version;
-  bool ok = tmp.Get("version",tmp_version);
-  if(ok && version){
-    *version = tmp_version;
-  }
-  if(!ok){
-    std::clog<<"SendROOTplot error: invalid response: '"<<response<<"'"<<std::endl;
-    return false;
+  // response is the version number of the created config entry
+  if(version){
+    try {
+      *version = stoull(response);
+    } catch(std::exception& e){
+      std::clog<<"SendROOTplot error: invalid response: '"<<response<<"'"<<std::endl;
+      return false;
+    }
   }
   
   return true;
@@ -281,6 +269,7 @@ bool Services::SendPlotlyPlot(
     const std::string& layout,
     int*               version,
     const uint64_t     timestamp,
+    const unsigned int lifetime,
     const unsigned int timeout
 ) {
   return SendPlotlyPlot(
@@ -289,6 +278,7 @@ bool Services::SendPlotlyPlot(
       layout,
       version,
       timestamp,
+      lifetime,
       timeout
   );
 }
@@ -302,12 +292,15 @@ bool Services::SendPlotlyPlot(
     const std::string&              layout,
     int*                            version,
     const uint64_t                  timestamp,
+    const unsigned int              lifetime,
     const unsigned int              timeout
 ) {
   std::stringstream ss;
-  ss << "{\"name\":\"" << name << "\",\"layout\":" << layout;
-  if (timestamp) ss << ",\"time\":" << timestamp;
-  ss << ",\"data\":[";
+  ss << "{   \"name\":\"" << name
+     << "\", \"time\":\"" << TimeStringFromUnixMs(timestamp)
+     << "\", \"lifetime\":" << lifetime
+     << ",   \"layout\":" << layout
+     << ",   \"data\":[";
   bool first = true;
   for (auto& trace : traces) {
     if (first)
@@ -331,18 +324,14 @@ bool Services::SendPlotlyPlot(
     return false;
   }
   
-  // response is json with the version number of the created plot entry
-  // e.g. '{"version":3}'. check this is what we got, as validation.
-  Store tmp;
-  tmp.JsonParser(response);
-  int tmp_version;
-  bool ok = tmp.Get("version",tmp_version);
-  if(ok && version){
-    *version = tmp_version;
-  }
-  if(!ok){
-    std::clog<<"SendPlotlyPlot error: invalid response: '"<<response<<"'"<<std::endl;
-    return false;
+  // response is the version number of the created config entry
+  if(version){
+    try {
+      *version = stoull(response);
+    } catch(std::exception& e){
+      std::clog<<"SendPlotlyPlot error: invalid response: '"<<response<<"'"<<std::endl;
+      return false;
+    }
   }
   
   return true;
@@ -407,7 +396,7 @@ bool Services::SQLQuery(/*const std::string& database,*/ const std::string& quer
 // --------------
 // we need to ensure any escaping needed is already done, but probably none needed
 
-bool Services::GetCalibrationData(std::string& json_data, int& version, const std::string& device, const unsigned int timeout){
+bool Services::GetCalibrationData(std::string& json_data, int version, const std::string& device, const unsigned int timeout){
   
   json_data = "";
   
@@ -417,9 +406,9 @@ bool Services::GetCalibrationData(std::string& json_data, int& version, const st
   
   if(version<0){
     // https://stackoverflow.com/questions/tagged/greatest-n-per-group for faster
-    cmd_string = "SELECT row_to_json(data, version) FROM calibration WHERE name='"+name+"' ORDER BY version DESC LIMIT 1";
+    cmd_string = "SELECT jsonb_build_object('data', data) FROM calibration WHERE name='"+name+"' ORDER BY version DESC LIMIT 1";
   } else {
-    cmd_string = "SELECT row_to_json(data, version) FROM calibration WHERE device='"+name+"' AND version="+std::to_string(version);
+    cmd_string = "SELECT jsonb_build_object('data', data) FROM calibration WHERE device='"+name+"' AND version="+std::to_string(version);
   }
   
   std::string err="";
@@ -441,15 +430,10 @@ bool Services::GetCalibrationData(std::string& json_data, int& version, const st
   
   Store tmp;
   tmp.JsonParser(json_data);
-  int tmp_version;
-  bool ok = tmp.Get("version",tmp_version);
-  if(ok && version<0){
-    version = tmp_version;
-  }
-  ok = ok && tmp.Get("data",json_data);
+  bool ok = tmp.Get("data",json_data);
   
   if(!ok){
-    err = "GetCalibrationData error: invalid response: '"+response+"'";
+    err = "GetCalibrationData error: invalid response: '"+json_data+"'";
     std::clog<<err<<std::endl;
     json_data = err;
     return false;
@@ -462,13 +446,19 @@ bool Services::GetCalibrationData(std::string& json_data, int& version, const st
 
 // ««-------------- ≪ °◇◆◇° ≫ --------------»»
 
-bool Services::GetDeviceConfig(std::string& json_data, int& version, const std::string& device, const unsigned int timeout){
+bool Services::GetDeviceConfig(std::string& json_data, const int version, const std::string& device, const unsigned int timeout){
 
   json_data="";
   
   const std::string& name = (device=="") ? m_name : device;
   
-  std::string cmd_string = "SELECT row_to_json(data) FROM device_config WHERE name='"+name+"' AND version="+std::to_string(version);
+  std::string cmd_string;
+  if(version<0){
+    // https://stackoverflow.com/questions/tagged/greatest-n-per-group for faster
+    cmd_string = "SELECT jsonb_build_object('data', data) FROM device_config WHERE device='"+name+"' ORDER BY version DESC LIMIT 1";
+  } else {
+  cmd_string = "SELECT jsonb_build_object('data', data) FROM device_config WHERE device='"+name+"' AND version="+std::to_string(version);
+  }
   
   std::string err="";
   
@@ -509,7 +499,7 @@ bool Services::GetRunConfig(std::string& json_data, const int config_id, const u
 
   json_data="";
   
-  std::string cmd_string = "SELECT row_to_json(data) FROM run_config WHERE config_id="+std::to_string(config_id);
+  std::string cmd_string = "SELECT jsonb_build_object('data', data) FROM run_config WHERE config_id="+std::to_string(config_id);
   
   std::string err="";
   
@@ -550,7 +540,7 @@ bool Services::GetRunConfig(std::string& json_data, const std::string& name, con
 
   json_data="";
   
-  std::string cmd_string = "SELECT row_to_json(data) FROM run_config WHERE name='"+name+"' AND version="+std::to_string(version);
+  std::string cmd_string = "SELECT jsonb_build_object('data, data) FROM run_config WHERE name='"+name+"' AND version="+std::to_string(version);
   
   std::string err="";
   
@@ -593,7 +583,7 @@ bool Services::GetRunDeviceConfig(std::string& json_data, const int runconfig_id
   
   const std::string& name = (device=="") ? m_name : device;
   
-  std::string cmd_string = "SELECT row_to_json(data, version) FROM device_config WHERE name='"+name+"' AND version=(SELECT data->>'"+name+"' FROM run_config WHERE config_id="+std::to_string(runconfig_id)+")";
+  std::string cmd_string = "SELECT jsonb_build_object('data', data, 'version', version) FROM device_config WHERE name='"+name+"' AND version=(SELECT data->>'"+name+"' FROM run_config WHERE config_id="+std::to_string(runconfig_id)+")";
   
   std::string err="";
   
@@ -606,7 +596,7 @@ bool Services::GetRunDeviceConfig(std::string& json_data, const int runconfig_id
   if(json_data.empty()){
     // if we got an empty response but the command succeeded,
     // the query worked but matched no records - run config not found
-    err = "GetRunDeviceConfig error: config "+name+" for runconfig "+std::to_string(runconfig_id)+" not found"
+    err = "GetRunDeviceConfig error: config "+name+" for runconfig "+std::to_string(runconfig_id)+" not found";
     std::clog<<err<<std::endl;
     json_data = err;
     return false;
@@ -641,7 +631,7 @@ bool Services::GetRunDeviceConfig(std::string& json_data, const std::string& run
   
   const std::string& name = (device=="") ? m_name : device;
   
-    std::string cmd_string = "SELECT row_to_json(data, version) FROM device_config WHERE name='"+name+"' AND version=(SELECT data->>'"+name+"' FROM run_config WHERE name='"+runconfig_name+"' AND version="+std::to_string(runconfig_version)+")";
+    std::string cmd_string = "SELECT jsonb_build_object('data', data, 'version', version) FROM device_config WHERE name='"+name+"' AND version=(SELECT data->>'"+name+"' FROM run_config WHERE name='"+runconfig_name+"' AND version="+std::to_string(runconfig_version)+")";
   
   std::string err="";
   
@@ -682,15 +672,15 @@ bool Services::GetRunDeviceConfig(std::string& json_data, const std::string& run
 
 // ««-------------- ≪ °◇◆◇° ≫ --------------»»
 
-bool Services::GetROOTplot(const std::string& plot_name, int& version, std::string& draw_options, std::string& json_data, std::string* timestamp, const unsigned int timeout){
+bool Services::GetROOTplot(const std::string& plot_name, int& version, std::string& draw_options, std::string& json_data, const unsigned int timeout){
   
   std::string cmd_string;
   
   if(version<0){
-    cmd_string = "SELECT row_to_json(version, time, data, draw_options), FROM rootplots WHERE name='"+plot_name+"' AND version="+std::to_string(version);
+    cmd_string = "SELECT jsonb_build_object('version', version, 'data', data, 'draw_options', draw_options), FROM rootplots WHERE name='"+plot_name+"' AND version="+std::to_string(version);
   } else {
     // https://stackoverflow.com/questions/tagged/greatest-n-per-group for faster
-    cmd_string = "SELECT row_to_json(version, time, data, draw_options) FROM rootplots WHERE name='"+plot_name+"' ORDER BY version DESC LIMIT 1";
+    cmd_string = "SELECT jsonb_build_object('version', version, 'data', data, 'draw_options', draw_options) FROM rootplots WHERE name='"+plot_name+"' ORDER BY version DESC LIMIT 1";
   }
   
   std::string err="";
@@ -714,7 +704,6 @@ bool Services::GetROOTplot(const std::string& plot_name, int& version, std::stri
   bool ok = plot.Get("data", json_data);
   ok = ok && plot.Get("draw_options", draw_options);
   ok = ok && plot.Get("version", version);
-  if(timestamp && ok) ok = ok && plot.Get("time", *timestamp);
   
   if(!ok){
     err="GetROOTplot error: invalid response: '"+response+"'";
@@ -724,8 +713,7 @@ bool Services::GetROOTplot(const std::string& plot_name, int& version, std::stri
   }
   
   /*
-  std::clog<<"timestamp: "<<timestamp<<"\n"
-           <<"draw opts: "<<draw_options<<"\n"
+  std::clog<<"draw opts: "<<draw_options<<"\n"
            <<"json data: '"<<json_data<<"'"<<std::endl;
   */
   
@@ -740,29 +728,28 @@ bool Services::GetPlotlyPlot(
     int&               version,
     std::string&       trace,
     std::string&       layout,
-    std::string*       timestamp,
     unsigned int       timeout
 ) {
   
   std::string cmd_string;
   if(version<0){
-    cmd_string = "SELECT row_to_json(version, time, data, layout), FROM plotlyplots WHERE name='"+name+"' AND version="+std::to_string(version);
+    cmd_string = "SELECT jsonb_build_object('version', version, 'data', data, 'layout', layout), FROM plotlyplots WHERE name='"+name+"' AND version="+std::to_string(version);
   } else {
     // https://stackoverflow.com/questions/tagged/greatest-n-per-group for faster
-    cmd_string = "SELECT row_to_json(version, time, data, layout) FROM plotlyplots WHERE name='"+name+"' ORDER BY version DESC LIMIT 1";
+    cmd_string = "SELECT jsonb_build_object('vesion', version, 'data', data, 'layout', layout) FROM plotlyplots WHERE name='"+name+"' ORDER BY version DESC LIMIT 1";
   }
   
   std::string err;
   std::string response;
   if (!m_backend_client.SendCommand("R_PLOTLYPLOT", cmd_string, &response, &timeout, &err)){
     std::clog << "GetPlotlyPlot error: " << err << std::endl;
-    json_data = err;
+    trace = err;
     return false;
   };
   
   if(response.empty()){
     err = "GetPlotlyPlot error: PlotlyPlot "+name+" version "+std::to_string(version)+" not found";
-    json_data = err;
+    trace = err;
     return false;
   }
   
@@ -776,12 +763,11 @@ bool Services::GetPlotlyPlot(
   bool ok = plot.Get("data", trace);
   ok = ok && plot.Get("layout", layout);
   ok = ok && plot.Get("version", version);
-  if(timestamp && ok) ok = ok && plot.Get("time", *timestamp);
   
   if(!ok){
     err="GetPlotlyPlot error: invalid response: '"+response+"'";
     std::clog<<err<<std::endl;
-    json_data=err;
+    trace=err;
     return false;
   }
   
@@ -797,14 +783,14 @@ bool Services::SendLog(const std::string& message, unsigned int severity, const 
   
   const std::string& name = (device=="") ? m_name : device;
   
-  std::string cmd_string = std::string{"{ \"topic\":\"LOGGING\""}
-                         + ",\"time\":"+std::to_string(timestamp)
+  std::string cmd_string = std::string{"{\"topic\":\"LOGGING\""}
+                         + ",\"time\":\""+TimeStringFromUnixMs(timestamp)+"\""
                          + ",\"device\":\""+ name +"\""
                          + ",\"severity\":"+std::to_string(severity)
                          + ",\"message\":\"" +  message + "\"}";
   
-  if(cmd_string.length()>655355){
-    std::clog<<"Logging message is too long! Maximum length may be 655355 bytes"<<std::endl;
+  if(cmd_string.length()>MAX_UDP_PACKET_SIZE){
+    std::clog<<"Logging message is too long! Maximum length may be MAX_UDP_PACKET_SIZE bytes"<<std::endl;
     return false;
   }
   
@@ -824,14 +810,14 @@ bool Services::SendMonitoringData(const std::string& json_data, const std::strin
   
   const std::string& name = (device=="") ? m_name : device;
   
-  std::string cmd_string = std::string{"{ \"topic\":\"MONITORING\""}
-                         + ", \"time\":"+std::to_string(timestamp)
+  std::string cmd_string = std::string{"{\"topic\":\"MONITORING\""}
+                         + ", \"time\":\""+TimeStringFromUnixMs(timestamp)+"\""
                          + ", \"device\":\""+ name +"\""
                          + ", \"subject\":\""+ subject +"\""
                          + ", \"data\":\""+ json_data +"\" }";
   
-  if(cmd_string.length()>655355){
-    std::clog<<"Monitoring message is too long! Maximum length may be 655355 bytes"<<std::endl;
+  if(cmd_string.length()>MAX_UDP_PACKET_SIZE){
+    std::clog<<"Monitoring message is too long! Maximum length may be MAX_UDP_PACKET_SIZE bytes"<<std::endl;
     return false;
   }
   
@@ -847,16 +833,17 @@ bool Services::SendMonitoringData(const std::string& json_data, const std::strin
 }
 
 // send ROOT plot over multicast
-bool Services::SendROOTplotMulticast(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, const uint64_t timestamp){
+bool Services::SendROOTplotMulticast(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, const unsigned int lifetime, const uint64_t timestamp){
   
-  std::string cmd_string = std::string{"{ \"topic\":\"TROOTPLOT\""}
-                         + ", \"time\":"+std::to_string(timestamp)
+  std::string cmd_string = std::string{"{\"topic\":\"TROOTPLOT\""}
+                         + ", \"time\":\""+TimeStringFromUnixMs(timestamp)+"\""
                          + ", \"name\":\""+ plot_name +"\""
                          + ", \"draw_options\":\""+ draw_options +"\""
-                         + ", \"data\":\""+ json_data+"\" }";
+                         + ", \"lifetime\":"+std::to_string(lifetime)
+                         + ", \"data\":"+ json_data+"}";
   
-  if(cmd_string.length()>655355){
-    std::clog<<"ROOT plot json is too long! Maximum length may be 655355 bytes"<<std::endl;
+  if(cmd_string.length()>MAX_UDP_PACKET_SIZE){
+    std::clog<<"ROOT plot json is too long! Maximum length may be MAX_UDP_PACKET_SIZE bytes"<<std::endl;
     return false;
   }
   
@@ -925,5 +912,37 @@ std::string Services::PrintSlowControlVariables(){
 std::string Services::GetDeviceName(){
   
   return m_name;
+  
+}
+
+// ««-------------- ≪ °◇◆◇° ≫ --------------»»
+
+std::string Services::TimeStringFromUnixMs(const uint64_t timestamp){
+  
+  if(timestamp==0) return "now()";
+  
+  //std::cout<<"converting time "<<timestamp<<" to timestring"<<std::endl;
+  char timestring[24];
+  uint16_t timestamp_ms = timestamp%1000;
+  time_t timestamp_sec = timestamp/1000;  // time_t is equivalent to uint64_t
+  struct tm* timeptr = gmtime(&timestamp_sec);
+  //std::cout<<"timeptr is "<<timeptr<<std::endl;
+  if(timeptr==0){
+    //Log("gmtime error converting unix time '"+std::to_string(timestamp)+"' to time struct",v_error);
+    return "now";
+  }
+  int nchars = strftime(&timestring[0], 20, "%F %T", timeptr);
+  if(nchars==0){
+    //Log("strftime error converting time struct '"+std::to_string(timestamp)+"' to string",v_error);
+    return "now";
+  }
+  // add the milliseconds
+  nchars = snprintf(&timestring[19], 5, ".%03d", timestamp_ms);
+  if(nchars!=4){
+    //Log("snprintf error converting '"+std::to_string(timestamp_ms)+"' to timestamp milliseconds",v_error);
+    //return "now";  // just omit the milliseconds? or fall back to 'now'?
+  }
+  
+  return std::string{timestring};
   
 }

--- a/src/ServiceDiscovery/Services.cpp
+++ b/src/ServiceDiscovery/Services.cpp
@@ -303,10 +303,8 @@ bool Services::SendPlotlyPlot(
      << ",   \"data\":[";
   bool first = true;
   for (auto& trace : traces) {
-    if (first)
-      first = false;
-    else
-      ss << ',';
+    if (!first) ss << ',';
+    first = false;
     ss << trace;
   };
   ss << "]}";
@@ -546,7 +544,7 @@ bool Services::GetRunConfig(std::string& json_data, const std::string& name, con
 
   json_data="";
   
-  std::string cmd_string = "SELECT jsonb_build_object('data, data) FROM run_config WHERE name='"+name+"' AND version="+std::to_string(version);
+  std::string cmd_string = "SELECT jsonb_build_object('data', data) FROM run_config WHERE name='"+name+"' AND version="+std::to_string(version);
   
   std::string err="";
   
@@ -589,7 +587,7 @@ bool Services::GetRunDeviceConfig(std::string& json_data, const int runconfig_id
   
   const std::string& name = (device=="") ? m_name : device;
   
-  std::string cmd_string = "SELECT jsonb_build_object('data', data, 'version', version) FROM device_config WHERE name='"+name+"' AND version=(SELECT data->>'"+name+"' FROM run_config WHERE config_id="+std::to_string(runconfig_id)+")";
+  std::string cmd_string = "SELECT jsonb_build_object('data', data, 'version', version) FROM device_config WHERE device='"+name+"' AND version=(SELECT data->>'"+name+"' FROM run_config WHERE config_id="+std::to_string(runconfig_id)+")";
   
   std::string err="";
   
@@ -637,7 +635,7 @@ bool Services::GetRunDeviceConfig(std::string& json_data, const std::string& run
   
   const std::string& name = (device=="") ? m_name : device;
   
-    std::string cmd_string = "SELECT jsonb_build_object('data', data, 'version', version) FROM device_config WHERE name='"+name+"' AND version=(SELECT data->>'"+name+"' FROM run_config WHERE name='"+runconfig_name+"' AND version="+std::to_string(runconfig_version)+")";
+    std::string cmd_string = "SELECT jsonb_build_object('data', data, 'version', version) FROM device_config WHERE device='"+name+"' AND version=(SELECT data->>'"+name+"' FROM run_config WHERE name='"+runconfig_name+"' AND version="+std::to_string(runconfig_version)+")";
   
   std::string err="";
   
@@ -683,7 +681,7 @@ bool Services::GetROOTplot(const std::string& plot_name, std::string& draw_optio
   std::string cmd_string;
   
   if(version<0){
-    cmd_string = "SELECT jsonb_build_object('version', version, 'data', data, 'draw_options', draw_options), FROM rootplots WHERE name='"+plot_name+"' AND version="+std::to_string(version);
+    cmd_string = "SELECT jsonb_build_object('version', version, 'data', data, 'draw_options', draw_options) FROM rootplots WHERE name='"+plot_name+"' AND version="+std::to_string(version);
   } else {
     // https://stackoverflow.com/questions/tagged/greatest-n-per-group for faster
     cmd_string = "SELECT jsonb_build_object('version', version, 'data', data, 'draw_options', draw_options) FROM rootplots WHERE name='"+plot_name+"' ORDER BY version DESC LIMIT 1";
@@ -745,7 +743,7 @@ bool Services::GetPlotlyPlot(
   
   std::string cmd_string;
   if(version<0){
-    cmd_string = "SELECT jsonb_build_object('version', version, 'data', data, 'layout', layout), FROM plotlyplots WHERE name='"+name+"' AND version="+std::to_string(version);
+    cmd_string = "SELECT jsonb_build_object('version', version, 'data', data, 'layout', layout) FROM plotlyplots WHERE name='"+name+"' AND version="+std::to_string(version);
   } else {
     // https://stackoverflow.com/questions/tagged/greatest-n-per-group for faster
     cmd_string = "SELECT jsonb_build_object('vesion', version, 'data', data, 'layout', layout) FROM plotlyplots WHERE name='"+name+"' ORDER BY version DESC LIMIT 1";
@@ -826,7 +824,7 @@ bool Services::SendMonitoringData(const std::string& json_data, const std::strin
                          + ", \"time\":\""+TimeStringFromUnixMs(timestamp)+"\""
                          + ", \"device\":\""+ name +"\""
                          + ", \"subject\":\""+ subject +"\""
-                         + ", \"data\":\""+ json_data +"\" }";
+                         + ", \"data\":"+ json_data +" }";
   
   if(cmd_string.length()>MAX_UDP_PACKET_SIZE){
     std::cerr<<"Monitoring message is too long! Maximum length may be MAX_UDP_PACKET_SIZE bytes"<<std::endl;
@@ -931,28 +929,32 @@ std::string Services::GetDeviceName(){
 
 std::string Services::TimeStringFromUnixMs(const uint64_t timestamp){
   
-  if(timestamp==0) return "now()";
+  if(timestamp==1) return "now()";  // remotely interpret 'now'
   
-  //std::cout<<"converting time "<<timestamp<<" to timestring"<<std::endl;
-  char timestring[24];
-  uint16_t timestamp_ms = timestamp%1000;
-  time_t timestamp_sec = timestamp/1000;  // time_t is equivalent to uint64_t
+  time_t timestamp_sec; // time_t is equivalent to uint64_t
+  uint16_t timestamp_ms = 0;
+  if(timestamp==0){
+    timestamp_sec = time(nullptr)*1000; // locally interpret 'now'
+  } else {
+    timestamp_ms = timestamp%1000;
+    timestamp_sec = timestamp/1000;
+  }
   struct tm* timeptr = gmtime(&timestamp_sec);
-  //std::cout<<"timeptr is "<<timeptr<<std::endl;
   if(timeptr==0){
     //Log("gmtime error converting unix time '"+std::to_string(timestamp)+"' to time struct",v_error);
-    return "now";
+    return "now()";
   }
+  char timestring[24];
   int nchars = strftime(&timestring[0], 20, "%F %T", timeptr);
   if(nchars==0){
     //Log("strftime error converting time struct '"+std::to_string(timestamp)+"' to string",v_error);
-    return "now";
+    return "now()";
   }
   // add the milliseconds
   nchars = snprintf(&timestring[19], 5, ".%03d", timestamp_ms);
   if(nchars!=4){
     //Log("snprintf error converting '"+std::to_string(timestamp_ms)+"' to timestamp milliseconds",v_error);
-    //return "now";  // just omit the milliseconds? or fall back to 'now'?
+    //return "now()";  // just omit the milliseconds? or fall back to 'now'?
   }
   
   return std::string{timestring};

--- a/src/ServiceDiscovery/Services.cpp
+++ b/src/ServiceDiscovery/Services.cpp
@@ -46,7 +46,7 @@ bool Services::Init(Store &m_variables, zmq::context_t* context_in, SlowControlC
 
   
   if(!m_backend_client.Initialise(m_variables)){
-    std::clog<<"error initialising slowcontrol client"<<std::endl;
+    std::cerr<<"error initialising slowcontrol client"<<std::endl;
     return false;
   }
    
@@ -84,7 +84,7 @@ bool Services::SendAlarm(const std::string& message, unsigned int level, const s
   // send the alarm on the pub socket
   bool ok = m_backend_client.SendCommand("W_ALARM", cmd_string, (std::vector<std::string>*)nullptr, &timeout, &err);
   if(!ok){
-    std::clog<<"SendAlarm error: "<<err<<std::endl;
+    std::cerr<<"SendAlarm error: "<<err<<std::endl;
   }
   // SendAlarm returns nothing
   
@@ -98,7 +98,7 @@ bool Services::SendAlarm(const std::string& message, unsigned int level, const s
   ok = ok && m_backend_client.SendMulticast(MulticastType::Log,cmd_string, &err);
   
   if(!ok){
-    std::clog<<"SendAlarm (log) error: "<<err<<std::endl;
+    std::cerr<<"SendAlarm (log) error: "<<err<<std::endl;
   }
   
   return ok;
@@ -120,12 +120,12 @@ bool Services::SendCalibrationData(const std::string& json_data, const std::stri
   std::string response="";
   
   if(!m_backend_client.SendCommand("W_CALIBRATION", cmd_string, &response, &timeout, &err)){
-    std::clog<<"SendCalibrationData error: "<<err<<std::endl;
+    std::cerr<<"SendCalibrationData error: "<<err<<std::endl;
     return false;
   }
   
   if(response.empty()){
-    std::clog<<"SendCalibrationData error: empty response"<<std::endl;
+    std::cerr<<"SendCalibrationData error: empty response"<<std::endl;
     return false;
   }
   
@@ -134,7 +134,7 @@ bool Services::SendCalibrationData(const std::string& json_data, const std::stri
     try {
       *version = stoull(response);
     } catch(std::exception& e){
-      std::clog<<"SendCalibrationData error: invalid response: '"<<response<<"'"<<std::endl;
+      std::cerr<<"SendCalibrationData error: invalid response: '"<<response<<"'"<<std::endl;
       return false;
     }
   }
@@ -161,12 +161,12 @@ bool Services::SendDeviceConfig(const std::string& json_data, const std::string&
   std::string err="";
   
   if(!m_backend_client.SendCommand("W_DEVCONFIG", cmd_string, &response, &timeout, &err)){
-    std::clog<<"SendDeviceConfig error: "<<err<<std::endl;
+    std::cerr<<"SendDeviceConfig error: "<<err<<std::endl;
     return false;
   }
   
   if(response.empty()){
-    std::clog<<"SendDeviceConfig error: empty response"<<std::endl;
+    std::cerr<<"SendDeviceConfig error: empty response"<<std::endl;
     return false;
   }
   
@@ -175,7 +175,7 @@ bool Services::SendDeviceConfig(const std::string& json_data, const std::string&
     try {
       *version = stoull(response);
     } catch(std::exception& e){
-      std::clog<<"SendDeviceConfig error: invalid response: '"<<response<<"'"<<std::endl;
+      std::cerr<<"SendDeviceConfig error: invalid response: '"<<response<<"'"<<std::endl;
       return false;
     }
   }
@@ -200,12 +200,12 @@ bool Services::SendRunConfig(const std::string& json_data, const std::string& na
   std::string err="";
   
   if(!m_backend_client.SendCommand("W_RUNCONFIG", cmd_string, &response, &timeout, &err)){
-    std::clog<<"SendRunConfig error: "<<err<<std::endl;
+    std::cerr<<"SendRunConfig error: "<<err<<std::endl;
     return false;
   }
   
   if(response.empty()){
-    std::clog<<"SendRunConfig error: empty response"<<std::endl;
+    std::cerr<<"SendRunConfig error: empty response"<<std::endl;
     return false;
   }
   
@@ -214,7 +214,7 @@ bool Services::SendRunConfig(const std::string& json_data, const std::string& na
     try {
       *version = stoull(response);
     } catch(std::exception& e){
-      std::clog<<"SendRunConfig error: invalid response: '"<<response<<"'"<<std::endl;
+      std::cerr<<"SendRunConfig error: invalid response: '"<<response<<"'"<<std::endl;
       return false;
     }
   }
@@ -237,12 +237,12 @@ bool Services::SendROOTplotZmq(const std::string& plot_name, const std::string& 
   std::string response="";
   
   if(!m_backend_client.SendCommand("W_TROOTPLOT", cmd_string, &response, &timeout, &err)){
-    std::clog<<"SendROOTplot error: "<<err<<std::endl;
+    std::cerr<<"SendROOTplot error: "<<err<<std::endl;
     return false;
   }
   
   if(response.empty()){
-    std::clog<<"SendROOTplot error: empty response"<<std::endl;
+    std::cerr<<"SendROOTplot error: empty response"<<std::endl;
     return false;
   }
   
@@ -251,7 +251,7 @@ bool Services::SendROOTplotZmq(const std::string& plot_name, const std::string& 
     try {
       *version = stoull(response);
     } catch(std::exception& e){
-      std::clog<<"SendROOTplot error: invalid response: '"<<response<<"'"<<std::endl;
+      std::cerr<<"SendROOTplot error: invalid response: '"<<response<<"'"<<std::endl;
       return false;
     }
   }
@@ -315,12 +315,12 @@ bool Services::SendPlotlyPlot(
   
   std::string err;
   if (!m_backend_client.SendCommand("W_PLOTLYPLOT", ss.str(), &response, &timeout, &err)){
-    std::clog << "SendPlotlyPlot error: " << err << std::endl;
+    std::cerr << "SendPlotlyPlot error: " << err << std::endl;
     return false;
   };
   
   if(response.empty()){
-    std::clog<<"SendPlotlyPlot error: empty response"<<std::endl;
+    std::cerr<<"SendPlotlyPlot error: empty response"<<std::endl;
     return false;
   }
   
@@ -329,7 +329,7 @@ bool Services::SendPlotlyPlot(
     try {
       *version = stoull(response);
     } catch(std::exception& e){
-      std::clog<<"SendPlotlyPlot error: invalid response: '"<<response<<"'"<<std::endl;
+      std::cerr<<"SendPlotlyPlot error: invalid response: '"<<response<<"'"<<std::endl;
       return false;
     }
   }
@@ -350,7 +350,7 @@ bool Services::SQLQuery(/*const std::string& database,*/ const std::string& quer
   std::string err="";
   
   if(!m_backend_client.SendCommand("W_QUERY", query, &responses, &timeout, &err)){
-    std::clog<<"SQLQuery error: "<<err<<std::endl;
+    std::cerr<<"SQLQuery error: "<<err<<std::endl;
     responses.resize(1);
     responses.front() = err;
     return false;
@@ -374,7 +374,7 @@ bool Services::SQLQuery(/*const std::string& database,*/ const std::string& quer
   if(responses.size()!=0){
     response = responses.front();
     if(responses.size()>1){
-      std::clog<<"Warning: SQLQuery returned multiple rows, only first returned"<<std::endl;
+      std::cout<<"Warning: SQLQuery returned multiple rows, only first returned"<<std::endl;
     }
   }
   
@@ -414,7 +414,7 @@ bool Services::GetCalibrationData(std::string& json_data, int& version, const st
   std::string err="";
   
   if(!m_backend_client.SendCommand("R_CALIBRATION", cmd_string, &json_data, &timeout, &err)){
-    std::clog<<"GetCalibrationData error: "<<err<<std::endl;
+    std::cerr<<"GetCalibrationData error: "<<err<<std::endl;
     json_data = err;
     return false;
   }
@@ -423,7 +423,7 @@ bool Services::GetCalibrationData(std::string& json_data, int& version, const st
     // if we got an empty response but the command succeeded,
     // the query worked but matched no records - run config not found
     err = "GetCalibrationData error: data for device "+name+" version "+std::to_string(version)+" not found";
-    std::clog<<err<<std::endl;
+    std::cerr<<err<<std::endl;
     json_data = err;
     return false;
   }
@@ -435,7 +435,7 @@ bool Services::GetCalibrationData(std::string& json_data, int& version, const st
   
   if(!ok){
     err = "GetCalibrationData error: invalid response: '"+json_data+"'";
-    std::clog<<err<<std::endl;
+    std::cerr<<err<<std::endl;
     json_data = err;
     return false;
   }
@@ -469,7 +469,7 @@ bool Services::GetDeviceConfig(std::string& json_data, const int version, const 
   std::string err="";
   
   if(!m_backend_client.SendCommand("R_DEVCONFIG", cmd_string, &json_data, &timeout, &err)){
-    std::clog<<"GetDeviceConfig error: "<<err<<std::endl;
+    std::cerr<<"GetDeviceConfig error: "<<err<<std::endl;
     json_data = err;
     return false;
   }
@@ -478,7 +478,7 @@ bool Services::GetDeviceConfig(std::string& json_data, const int version, const 
     // if we got an empty response but the command succeeded,
     // the query worked but matched no records - run config not found
     err = "GetDeviceConfig error: config for device "+name+" version "+std::to_string(version)+" not found";
-    std::clog<<err<<std::endl;
+    std::cerr<<err<<std::endl;
     json_data = err;
     return false;
   }
@@ -489,7 +489,7 @@ bool Services::GetDeviceConfig(std::string& json_data, const int version, const 
   bool ok = tmp.Get("data", json_data);
   if(!ok){
     err = "GetDeviceConfig error: invalid response: '"+json_data+"'";
-    std::clog<<err<<std::endl;
+    std::cerr<<err<<std::endl;
     json_data = err;
     return false;
   }
@@ -510,7 +510,7 @@ bool Services::GetRunConfig(std::string& json_data, const int config_id, const u
   std::string err="";
   
   if(!m_backend_client.SendCommand("R_RUNCONFIG", cmd_string, &json_data, &timeout, &err)){
-    std::clog<<"GetRunConfig error: "<<err<<std::endl;
+    std::cerr<<"GetRunConfig error: "<<err<<std::endl;
     json_data = err;
     return false;
   }
@@ -519,7 +519,7 @@ bool Services::GetRunConfig(std::string& json_data, const int config_id, const u
     // if we got an empty response but the command succeeded,
     // the query worked but matched no records - run config not found
     err = "GetRunConfig error: config_id "+std::to_string(config_id)+" not found";
-    std::clog<<err<<std::endl;
+    std::cerr<<err<<std::endl;
     json_data = err;
     return false;
   }
@@ -530,7 +530,7 @@ bool Services::GetRunConfig(std::string& json_data, const int config_id, const u
   bool ok = tmp.Get("data", json_data);
   if(!ok){
     err="GetRunConfig error: invalid response: '"+json_data+"'";
-    std::clog<<err<<std::endl;
+    std::cerr<<err<<std::endl;
     json_data=err;
     return false;
   }
@@ -551,7 +551,7 @@ bool Services::GetRunConfig(std::string& json_data, const std::string& name, con
   std::string err="";
   
   if(!m_backend_client.SendCommand("R_RUNCONFIG", cmd_string, &json_data, &timeout, &err)){
-    std::clog<<"GetRunConfig error: "<<err<<std::endl;
+    std::cerr<<"GetRunConfig error: "<<err<<std::endl;
     json_data = err;
     return false;
   }
@@ -560,7 +560,7 @@ bool Services::GetRunConfig(std::string& json_data, const std::string& name, con
     // if we got an empty response but the command succeeded,
     // the query worked but matched no records - run config not found
     err = "GetRunConfig error: config "+name+" version "+std::to_string(version)+" not found";
-    std::clog<<err<<std::endl;
+    std::cerr<<err<<std::endl;
     json_data = err;
     return false;
   }
@@ -571,7 +571,7 @@ bool Services::GetRunConfig(std::string& json_data, const std::string& name, con
   bool ok = tmp.Get("data", json_data);
   if(!ok){
     err="GetRunConfig error: invalid response: '"+json_data+"'";
-    std::clog<<err<<std::endl;
+    std::cerr<<err<<std::endl;
     json_data=err;
     return false;
   }
@@ -594,7 +594,7 @@ bool Services::GetRunDeviceConfig(std::string& json_data, const int runconfig_id
   std::string err="";
   
   if(!m_backend_client.SendCommand("R_DEVCONFIG", cmd_string, &json_data, &timeout, &err)){
-    std::clog<<"GetRunDeviceConfig error: "<<err<<std::endl;
+    std::cerr<<"GetRunDeviceConfig error: "<<err<<std::endl;
     json_data = err;
     return false;
   }
@@ -603,7 +603,7 @@ bool Services::GetRunDeviceConfig(std::string& json_data, const int runconfig_id
     // if we got an empty response but the command succeeded,
     // the query worked but matched no records - run config not found
     err = "GetRunDeviceConfig error: config "+name+" for runconfig "+std::to_string(runconfig_id)+" not found";
-    std::clog<<err<<std::endl;
+    std::cerr<<err<<std::endl;
     json_data = err;
     return false;
   }
@@ -619,7 +619,7 @@ bool Services::GetRunDeviceConfig(std::string& json_data, const int runconfig_id
   ok = ok && tmp.Get("data", json_data);
   if(!ok){
     err="GetRunDeviceConfig error: invalid response: '"+json_data+"'";
-    std::clog<<err<<std::endl;
+    std::cerr<<err<<std::endl;
     json_data=err;
     return false;
   }
@@ -642,7 +642,7 @@ bool Services::GetRunDeviceConfig(std::string& json_data, const std::string& run
   std::string err="";
   
   if(!m_backend_client.SendCommand("R_DEVCONFIG", cmd_string, &json_data, &timeout, &err)){
-    std::clog<<"GetRunDeviceConfig error: "<<err<<std::endl;
+    std::cerr<<"GetRunDeviceConfig error: "<<err<<std::endl;
     json_data = err;
     return false;
   }
@@ -651,7 +651,7 @@ bool Services::GetRunDeviceConfig(std::string& json_data, const std::string& run
     // if we got an empty response but the command succeeded,
     // the query worked but matched no records - run config not found
     err = "GetRunDeviceConfig error: config "+name+" for runconfig "+runconfig_name+" version "+std::to_string(runconfig_version)+" not found";
-    std::clog<<err<<std::endl;
+    std::cerr<<err<<std::endl;
     json_data = err;
     return false;
   }
@@ -667,7 +667,7 @@ bool Services::GetRunDeviceConfig(std::string& json_data, const std::string& run
   ok = ok && tmp.Get("data", json_data);
   if(!ok){
     err="GetRunDeviceConfig error: invalid response: '"+json_data+"'";
-    std::clog<<err<<std::endl;
+    std::cerr<<err<<std::endl;
     json_data=err;
     return false;
   }
@@ -693,7 +693,7 @@ bool Services::GetROOTplot(const std::string& plot_name, std::string& draw_optio
   std::string response="";
   
   if(!m_backend_client.SendCommand("R_TROOTPLOT", cmd_string, &response, &timeout, &err)){
-    std::clog<<"GetROOTplot error: "<<err<<std::endl;
+    std::cerr<<"GetROOTplot error: "<<err<<std::endl;
     json_data = err;
     return false;
   }
@@ -713,7 +713,7 @@ bool Services::GetROOTplot(const std::string& plot_name, std::string& draw_optio
   
   if(!ok){
     err="GetROOTplot error: invalid response: '"+response+"'";
-    std::clog<<err<<std::endl;
+    std::cerr<<err<<std::endl;
     json_data=err;
     return false;
   }
@@ -754,7 +754,7 @@ bool Services::GetPlotlyPlot(
   std::string err;
   std::string response;
   if (!m_backend_client.SendCommand("R_PLOTLYPLOT", cmd_string, &response, &timeout, &err)){
-    std::clog << "GetPlotlyPlot error: " << err << std::endl;
+    std::cerr << "GetPlotlyPlot error: " << err << std::endl;
     trace = err;
     return false;
   };
@@ -774,7 +774,7 @@ bool Services::GetPlotlyPlot(
   
   if(!ok){
     err="GetPlotlyPlot error: invalid response: '"+response+"'";
-    std::clog<<err<<std::endl;
+    std::cerr<<err<<std::endl;
     trace=err;
     return false;
   }
@@ -802,14 +802,14 @@ bool Services::SendLog(const std::string& message, unsigned int severity, const 
                          + ",\"message\":\"" +  message + "\"}";
   
   if(cmd_string.length()>MAX_UDP_PACKET_SIZE){
-    std::clog<<"Logging message is too long! Maximum length may be MAX_UDP_PACKET_SIZE bytes"<<std::endl;
+    std::cerr<<"Logging message is too long! Maximum length may be MAX_UDP_PACKET_SIZE bytes"<<std::endl;
     return false;
   }
   
   std::string err="";
   
   if(!m_backend_client.SendMulticast(MulticastType::Log,cmd_string, &err)){
-    std::clog<<"SendLog error: "<<err<<std::endl;
+    std::cerr<<"SendLog error: "<<err<<std::endl;
     return false;
   }
   
@@ -829,14 +829,14 @@ bool Services::SendMonitoringData(const std::string& json_data, const std::strin
                          + ", \"data\":\""+ json_data +"\" }";
   
   if(cmd_string.length()>MAX_UDP_PACKET_SIZE){
-    std::clog<<"Monitoring message is too long! Maximum length may be MAX_UDP_PACKET_SIZE bytes"<<std::endl;
+    std::cerr<<"Monitoring message is too long! Maximum length may be MAX_UDP_PACKET_SIZE bytes"<<std::endl;
     return false;
   }
   
   std::string err="";
   
   if(!m_backend_client.SendMulticast(MulticastType::Monitoring,cmd_string, &err)){
-    std::clog<<"SendMonitoringData error: "<<err<<std::endl;
+    std::cerr<<"SendMonitoringData error: "<<err<<std::endl;
     return false;
   }
   
@@ -855,14 +855,14 @@ bool Services::SendROOTplotMulticast(const std::string& plot_name, const std::st
                          + ", \"data\":"+ json_data+"}";
   
   if(cmd_string.length()>MAX_UDP_PACKET_SIZE){
-    std::clog<<"ROOT plot json is too long! Maximum length may be MAX_UDP_PACKET_SIZE bytes"<<std::endl;
+    std::cerr<<"ROOT plot json is too long! Maximum length may be MAX_UDP_PACKET_SIZE bytes"<<std::endl;
     return false;
   }
   
   std::string err="";
   
   if(!m_backend_client.SendMulticast(MulticastType::Log,cmd_string, &err)){
-    std::clog<<"SendROOTplot error: "<<err<<std::endl;
+    std::cerr<<"SendROOTplot error: "<<err<<std::endl;
     return false;
   }
   

--- a/src/ServiceDiscovery/Services.cpp
+++ b/src/ServiceDiscovery/Services.cpp
@@ -54,7 +54,9 @@ bool Services::Init(Store &m_variables, zmq::context_t* context_in, SlowControlC
   // so we need to wait for the middleman to receive one & connect before we can communicate with it.
   int pub_period=5;
   m_variables.Get("service_publish_sec",pub_period);
-  Ready(pub_period*1000);
+  if(!Ready(pub_period*3000)){ // Wait up to 3 broadcast periods. It'll return sooner if it connects.
+    std::cerr<<"Warning: service not yet connected..."<<std::endl;
+  }
   
   return true;
 }
@@ -679,10 +681,10 @@ bool Services::GetROOTplot(const std::string& plot_name, std::string& draw_optio
   std::string cmd_string;
   
   if(version<0){
-    cmd_string = "SELECT jsonb_build_object('version', version, 'data', data, 'draw_options', draw_options) FROM rootplots WHERE name='"+plot_name+"' AND version="+std::to_string(version);
-  } else {
     // https://stackoverflow.com/questions/tagged/greatest-n-per-group for faster
     cmd_string = "SELECT jsonb_build_object('version', version, 'data', data, 'draw_options', draw_options) FROM rootplots WHERE name='"+plot_name+"' ORDER BY version DESC LIMIT 1";
+  } else {
+    cmd_string = "SELECT jsonb_build_object('version', version, 'data', data, 'draw_options', draw_options) FROM rootplots WHERE name='"+plot_name+"' AND version="+std::to_string(version);
   }
   
   std::string err="";
@@ -738,13 +740,12 @@ bool Services::GetPlotlyPlot(
     int&               version,
     unsigned int       timeout
 ) {
-  
   std::string cmd_string;
   if(version<0){
-    cmd_string = "SELECT jsonb_build_object('version', version, 'data', data, 'layout', layout) FROM plotlyplots WHERE name='"+name+"' AND version="+std::to_string(version);
-  } else {
     // https://stackoverflow.com/questions/tagged/greatest-n-per-group for faster
-    cmd_string = "SELECT jsonb_build_object('vesion', version, 'data', data, 'layout', layout) FROM plotlyplots WHERE name='"+name+"' ORDER BY version DESC LIMIT 1";
+    cmd_string = "SELECT jsonb_build_object('version', version, 'data', data, 'layout', layout) FROM plotlyplots WHERE name='"+name+"' ORDER BY version DESC LIMIT 1";
+  } else {
+    cmd_string = "SELECT jsonb_build_object('version', version, 'data', data, 'layout', layout) FROM plotlyplots WHERE name='"+name+"' AND version="+std::to_string(version);
   }
   
   std::string err;

--- a/src/ServiceDiscovery/Services.cpp
+++ b/src/ServiceDiscovery/Services.cpp
@@ -95,9 +95,7 @@ bool Services::SendAlarm(const std::string& message, unsigned int level, const s
              + ",\"severity\":0"
              + ",\"message\":\"" + message + "\"}";
   
-  ok = ok && m_backend_client.SendMulticast(MulticastType::Log,cmd_string, &err);
-  
-  if(!ok){
+  if(!m_backend_client.SendMulticast(MulticastType::Log,cmd_string, &err)){
     std::cerr<<"SendAlarm (log) error: "<<err<<std::endl;
   }
   
@@ -587,7 +585,7 @@ bool Services::GetRunDeviceConfig(std::string& json_data, const int runconfig_id
   
   const std::string& name = (device=="") ? m_name : device;
   
-  std::string cmd_string = "SELECT jsonb_build_object('data', data, 'version', version) FROM device_config WHERE device='"+name+"' AND version=(SELECT data->>'"+name+"' FROM run_config WHERE config_id="+std::to_string(runconfig_id)+")";
+  std::string cmd_string = "SELECT jsonb_build_object('data', data, 'version', version) FROM device_config WHERE device='"+name+"' AND version=(SELECT data->>'"+name+"' FROM run_config WHERE config_id="+std::to_string(runconfig_id)+")::integer";
   
   std::string err="";
   
@@ -635,7 +633,7 @@ bool Services::GetRunDeviceConfig(std::string& json_data, const std::string& run
   
   const std::string& name = (device=="") ? m_name : device;
   
-    std::string cmd_string = "SELECT jsonb_build_object('data', data, 'version', version) FROM device_config WHERE device='"+name+"' AND version=(SELECT data->>'"+name+"' FROM run_config WHERE name='"+runconfig_name+"' AND version="+std::to_string(runconfig_version)+")";
+    std::string cmd_string = "SELECT jsonb_build_object('data', data, 'version', version) FROM device_config WHERE device='"+name+"' AND version=(SELECT data->>'"+name+"' FROM run_config WHERE name='"+runconfig_name+"' AND version="+std::to_string(runconfig_version)+")::integer";
   
   std::string err="";
   

--- a/src/ServiceDiscovery/Services.cpp
+++ b/src/ServiceDiscovery/Services.cpp
@@ -54,7 +54,7 @@ bool Services::Init(Store &m_variables, zmq::context_t* context_in, SlowControlC
   // so we need to wait for the middleman to receive one & connect before we can communicate with it.
   int pub_period=5;
   m_variables.Get("service_publish_sec",pub_period);
-  Ready(pub_period*3000); // wait for 3x SD publish period. Trial and error: Why so long needed?
+  Ready(pub_period*1000);
   
   return true;
 }
@@ -396,7 +396,7 @@ bool Services::SQLQuery(/*const std::string& database,*/ const std::string& quer
 // --------------
 // we need to ensure any escaping needed is already done, but probably none needed
 
-bool Services::GetCalibrationData(std::string& json_data, int version, const std::string& device, const unsigned int timeout){
+bool Services::GetCalibrationData(std::string& json_data, int& version, const std::string& device, const unsigned int timeout){
   
   json_data = "";
   
@@ -406,9 +406,9 @@ bool Services::GetCalibrationData(std::string& json_data, int version, const std
   
   if(version<0){
     // https://stackoverflow.com/questions/tagged/greatest-n-per-group for faster
-    cmd_string = "SELECT jsonb_build_object('data', data) FROM calibration WHERE name='"+name+"' ORDER BY version DESC LIMIT 1";
+    cmd_string = "SELECT jsonb_build_object('data', data, 'version', version) FROM calibration WHERE name='"+name+"' ORDER BY version DESC LIMIT 1";
   } else {
-    cmd_string = "SELECT jsonb_build_object('data', data) FROM calibration WHERE device='"+name+"' AND version="+std::to_string(version);
+    cmd_string = "SELECT jsonb_build_object('data', data, 'version', version) FROM calibration WHERE device='"+name+"' AND version="+std::to_string(version);
   }
   
   std::string err="";
@@ -431,6 +431,7 @@ bool Services::GetCalibrationData(std::string& json_data, int version, const std
   Store tmp;
   tmp.JsonParser(json_data);
   bool ok = tmp.Get("data",json_data);
+  ok = ok && tmp.Get("version",version);
   
   if(!ok){
     err = "GetCalibrationData error: invalid response: '"+json_data+"'";
@@ -442,6 +443,11 @@ bool Services::GetCalibrationData(std::string& json_data, int version, const std
   
   return true;
   
+}
+
+bool Services::GetCalibrationData(std::string& json_data, int&& version, const std::string& device, const unsigned int timeout){
+  int v = version;
+  return GetCalibrationData(json_data, v, device, timeout);
 }
 
 // ««-------------- ≪ °◇◆◇° ≫ --------------»»
@@ -672,7 +678,7 @@ bool Services::GetRunDeviceConfig(std::string& json_data, const std::string& run
 
 // ««-------------- ≪ °◇◆◇° ≫ --------------»»
 
-bool Services::GetROOTplot(const std::string& plot_name, int& version, std::string& draw_options, std::string& json_data, const unsigned int timeout){
+bool Services::GetROOTplot(const std::string& plot_name, std::string& draw_options, std::string& json_data, int& version, const unsigned int timeout){
   
   std::string cmd_string;
   
@@ -721,13 +727,19 @@ bool Services::GetROOTplot(const std::string& plot_name, int& version, std::stri
   
 }
 
-// Get a device configuration from a *run* configuration ID
+// version that accepts values in case user isn't interested in returned version
+bool Services::GetROOTplot(const std::string& plot_name, std::string& draw_options, std::string& json_data, int&& version, const unsigned int timeout){
+  int v = version;
+  return GetROOTplot(plot_name, draw_options, json_data, v, timeout);
+}
+
+// ««-------------- ≪ °◇◆◇° ≫ --------------»»
 
 bool Services::GetPlotlyPlot(
     const std::string& name,
-    int&               version,
     std::string&       trace,
     std::string&       layout,
+    int&               version,
     unsigned int       timeout
 ) {
   
@@ -756,10 +768,6 @@ bool Services::GetPlotlyPlot(
   Store plot;
   plot.JsonParser(response);
   
-  trace   = plot.Get<std::string>("data");
-  layout  = plot.Get<std::string>("layout");
-  version = plot.Get<int>("version");
-  
   bool ok = plot.Get("data", trace);
   ok = ok && plot.Get("layout", layout);
   ok = ok && plot.Get("version", version);
@@ -774,6 +782,10 @@ bool Services::GetPlotlyPlot(
   return true;
 }
 
+bool Services::GetPlotlyPlot(const std::string& name, std::string& trace, std::string& layout, int&& version, unsigned int timeout){
+  int v = version;
+  return GetPlotlyPlot(name, trace, layout, v, timeout);
+} 
 
 // ===========================================================================
 // Multicast Senders

--- a/src/ServiceDiscovery/Services.cpp
+++ b/src/ServiceDiscovery/Services.cpp
@@ -63,7 +63,7 @@ bool Services::Ready(const unsigned int timeout){
 // Write Functions
 // ---------------
 
-bool Services::SendAlarm(const std::string& message, unsigned int level, const std::string& device, unsigned int timestamp, const unsigned int timeout){
+bool Services::SendAlarm(const std::string& message, unsigned int level, const std::string& device, const uint64_t timestamp, const unsigned int timeout){
   
   const std::string& name = (device=="") ? m_name : device;
   
@@ -82,9 +82,10 @@ bool Services::SendAlarm(const std::string& message, unsigned int level, const s
   if(!ok){
     std::clog<<"SendAlarm error: "<<err<<std::endl;
   }
+  // SendAlarm returns nothing
   
   // also record it to the logging socket
-  cmd_string = std::string{"{ \"topic\":\"logging\""}
+  cmd_string = std::string{"{ \"topic\":\"LOGGING\""}
              + ",\"time\":"+std::to_string(timestamp)
              + ",\"device\":\""+name+"\""
              + ",\"severity\":0"
@@ -100,12 +101,14 @@ bool Services::SendAlarm(const std::string& message, unsigned int level, const s
   
 }
 
-bool Services::SendCalibrationData(const std::string& json_data, const std::string& description, const std::string& device, unsigned int timestamp, int* version, const unsigned int timeout){
+// ««-------------- ≪ °◇◆◇° ≫ --------------»»
+
+bool Services::SendCalibrationData(const std::string& json_data, const std::string& description, const std::string& name, const uint64_t timestamp, int* version, const unsigned int timeout){
   
-  const std::string& name = (device=="") ? m_name : device;
+  const std::string& c_name = (name=="") ? m_name : name;
   
   std::string cmd_string = "{ \"time\":"+std::to_string(timestamp)
-                         + ", \"device\":\""+ name +"\""
+                         + ", \"name\":\""+ c_name +"\""
                          + ", \"description\":\""+ description+"\""
                          + ", \"data\":\""+ json_data +"\" }";
   
@@ -114,6 +117,11 @@ bool Services::SendCalibrationData(const std::string& json_data, const std::stri
   
   if(!m_backend_client.SendCommand("W_CALIBRATION", cmd_string, &response, &timeout, &err)){
     std::clog<<"SendCalibrationData error: "<<err<<std::endl;
+    return false;
+  }
+  
+  if(response.empty()){
+    std::clog<<"SendCalibrationData error: empty response"<<std::endl;
     return false;
   }
   
@@ -135,7 +143,9 @@ bool Services::SendCalibrationData(const std::string& json_data, const std::stri
   
 }
 
-bool Services::SendDeviceConfig(const std::string& json_data, const std::string& author, const std::string& description, const std::string& device, unsigned int timestamp, int* version, const unsigned int timeout){
+// ««-------------- ≪ °◇◆◇° ≫ --------------»»
+
+bool Services::SendDeviceConfig(const std::string& json_data, const std::string& author, const std::string& description, const std::string& device, const uint64_t timestamp, int* version, const unsigned int timeout){
   
   if(version) *version=-1;
   
@@ -152,6 +162,11 @@ bool Services::SendDeviceConfig(const std::string& json_data, const std::string&
   
   if(!m_backend_client.SendCommand("W_DEVCONFIG", cmd_string, &response, &timeout, &err)){
     std::clog<<"SendDeviceConfig error: "<<err<<std::endl;
+    return false;
+  }
+  
+  if(response.empty()){
+    std::clog<<"SendDeviceConfig error: empty response"<<std::endl;
     return false;
   }
   
@@ -173,7 +188,9 @@ bool Services::SendDeviceConfig(const std::string& json_data, const std::string&
   
 }
 
-bool Services::SendRunConfig(const std::string& json_data, const std::string& name, const std::string& author, const std::string& description, unsigned int timestamp, int* version, const unsigned int timeout){
+// ««-------------- ≪ °◇◆◇° ≫ --------------»»
+
+bool Services::SendRunConfig(const std::string& json_data, const std::string& name, const std::string& author, const std::string& description, const uint64_t timestamp, int* version, const unsigned int timeout){
   
   if(version) *version=-1;
   
@@ -188,6 +205,11 @@ bool Services::SendRunConfig(const std::string& json_data, const std::string& na
   
   if(!m_backend_client.SendCommand("W_RUNCONFIG", cmd_string, &response, &timeout, &err)){
     std::clog<<"SendRunConfig error: "<<err<<std::endl;
+    return false;
+  }
+  
+  if(response.empty()){
+    std::clog<<"SendRunConfig error: empty response"<<std::endl;
     return false;
   }
   
@@ -209,18 +231,196 @@ bool Services::SendRunConfig(const std::string& json_data, const std::string& na
   
 }
 
+// ««-------------- ≪ °◇◆◇° ≫ --------------»»
+
+bool Services::SendROOTplotZmq(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, const unsigned int keep_until, int* version, const uint64_t timestamp, const unsigned int timeout){
+  
+  std::string cmd_string = "{ \"time\":"+std::to_string(timestamp)
+                         + ", \"name\":\""+ plot_name +"\""
+                         + ", \"draw_options\":\""+ draw_options +"\""
+                         + ", \"data\":\""+ json_data+"\""
+                         + ", \"keep_until\":"+std::to_string(keep_until)+" }"; // FIXME modify DB as per retention
+  
+  std::string err="";
+  std::string response="";
+  
+  if(!m_backend_client.SendCommand("W_TROOTPLOT", cmd_string, &response, &timeout, &err)){
+    std::clog<<"SendROOTplot error: "<<err<<std::endl;
+    return false;
+  }
+  
+  if(response.empty()){
+    std::clog<<"SendROOTplot error: empty response"<<std::endl;
+    return false;
+  }
+  
+  // response is json with the version number of the created plot entry
+  // e.g. '{"version":3}'. check this is what we got, as validation.
+  Store tmp;
+  tmp.JsonParser(response);
+  int tmp_version;
+  bool ok = tmp.Get("version",tmp_version);
+  if(ok && version){
+    *version = tmp_version;
+  }
+  if(!ok){
+    std::clog<<"SendROOTplot error: invalid response: '"<<response<<"'"<<std::endl;
+    return false;
+  }
+  
+  return true;
+  
+}
+
+// ««-------------- ≪ °◇◆◇° ≫ --------------»»
+
+// single trace version
+bool Services::SendPlotlyPlot(
+    const std::string& name,
+    const std::string& trace,
+    const std::string& layout,
+    int*               version,
+    const uint64_t     timestamp,
+    const unsigned int timeout
+) {
+  return SendPlotlyPlot(
+      name,
+      std::vector<std::string> { trace },
+      layout,
+      version,
+      timestamp,
+      timeout
+  );
+}
+
+// ««-------------- ≪ °◇◆◇° ≫ --------------»»
+
+// multiple traces version
+bool Services::SendPlotlyPlot(
+    const std::string&              name,
+    const std::vector<std::string>& traces,
+    const std::string&              layout,
+    int*                            version,
+    const uint64_t                  timestamp,
+    const unsigned int              timeout
+) {
+  std::stringstream ss;
+  ss << "{\"name\":\"" << name << "\",\"layout\":" << layout;
+  if (timestamp) ss << ",\"time\":" << timestamp;
+  ss << ",\"data\":[";
+  bool first = true;
+  for (auto& trace : traces) {
+    if (first)
+      first = false;
+    else
+      ss << ',';
+    ss << trace;
+  };
+  ss << "]}";
+  
+  std::string response="";
+  
+  std::string err;
+  if (!m_backend_client.SendCommand("W_PLOTLYPLOT", ss.str(), &response, &timeout, &err)){
+    std::clog << "SendPlotlyPlot error: " << err << std::endl;
+    return false;
+  };
+  
+  if(response.empty()){
+    std::clog<<"SendPlotlyPlot error: empty response"<<std::endl;
+    return false;
+  }
+  
+  // response is json with the version number of the created plot entry
+  // e.g. '{"version":3}'. check this is what we got, as validation.
+  Store tmp;
+  tmp.JsonParser(response);
+  int tmp_version;
+  bool ok = tmp.Get("version",tmp_version);
+  if(ok && version){
+    *version = tmp_version;
+  }
+  if(!ok){
+    std::clog<<"SendPlotlyPlot error: invalid response: '"<<response<<"'"<<std::endl;
+    return false;
+  }
+  
+  return true;
+}
+
+// ««-------------- ≪ °◇◆◇° ≫ --------------»»
+
+// Since we don't know if a generic SQL query is read or write, call it a write-query for safety
+// version that expects multiple returned rows
+bool Services::SQLQuery(/*const std::string& database,*/ const std::string& query, std::vector<std::string>& responses, const unsigned int timeout){
+  
+  responses.clear();
+  
+  //const std::string& db = (database=="") ? m_dbname : database;
+  
+  std::string err="";
+  
+  if(!m_backend_client.SendCommand("W_QUERY", query, &responses, &timeout, &err)){
+    std::clog<<"SQLQuery error: "<<err<<std::endl;
+    responses.resize(1);
+    responses.front() = err;
+    return false;
+  }
+  
+  return true;
+  
+}
+
+// ««-------------- ≪ °◇◆◇° ≫ --------------»»
+
+// version when expecting just one row
+bool Services::SQLQuery(/*const std::string& database,*/ const std::string& query, std::string& response, const unsigned int timeout){
+  
+  response="";
+  
+  std::vector<std::string> responses;
+  
+  bool ok = SQLQuery(/*db,*/ query, responses, timeout);
+  
+  if(responses.size()!=0){
+    response = responses.front();
+    if(responses.size()>1){
+      std::clog<<"Warning: SQLQuery returned multiple rows, only first returned"<<std::endl;
+    }
+  }
+  
+  return ok;
+}
+
+// ««-------------- ≪ °◇◆◇° ≫ --------------»»
+
+// versions that don't expect any return (e.g. insertions)
+bool Services::SQLQuery(/*const std::string& database,*/ const std::string& query, const unsigned int timeout){
+  
+  std::string tmp;
+  return SQLQuery(/*database,*/ query, tmp, timeout);
+
+}
+
 // ===========================================================================
 // Read Functions
 // --------------
+// we need to ensure any escaping needed is already done, but probably none needed
 
-bool Services::GetCalibrationData(std::string& json_data, int version, const std::string& device, const unsigned int timeout){
+bool Services::GetCalibrationData(std::string& json_data, int& version, const std::string& device, const unsigned int timeout){
   
   json_data = "";
   
   const std::string& name = (device=="") ? m_name : device;
   
-  std::string cmd_string = "{ \"device\":\""+ name +"\""
-                         + ", \"version\":\""+std::to_string(version)+"\" }";
+  std::string cmd_string;
+  
+  if(version<0){
+    // https://stackoverflow.com/questions/tagged/greatest-n-per-group for faster
+    cmd_string = "SELECT row_to_json(data, version) FROM calibration WHERE name='"+name+"' ORDER BY version DESC LIMIT 1";
+  } else {
+    cmd_string = "SELECT row_to_json(data, version) FROM calibration WHERE device='"+name+"' AND version="+std::to_string(version);
+  }
   
   std::string err="";
   
@@ -230,18 +430,45 @@ bool Services::GetCalibrationData(std::string& json_data, int version, const std
     return false;
   }
   
+  if(json_data.empty()){
+    // if we got an empty response but the command succeeded,
+    // the query worked but matched no records - run config not found
+    err = "GetCalibrationData error: data for device "+name+" version "+std::to_string(version)+" not found";
+    std::clog<<err<<std::endl;
+    json_data = err;
+    return false;
+  }
+  
+  Store tmp;
+  tmp.JsonParser(json_data);
+  int tmp_version;
+  bool ok = tmp.Get("version",tmp_version);
+  if(ok && version<0){
+    version = tmp_version;
+  }
+  ok = ok && tmp.Get("data",json_data);
+  
+  if(!ok){
+    err = "GetCalibrationData error: invalid response: '"+response+"'";
+    std::clog<<err<<std::endl;
+    json_data = err;
+    return false;
+  }
+  
+  
   return true;
   
 }
 
-bool Services::GetDeviceConfig(std::string& json_data, const int version, const std::string& device, const unsigned int timeout){
+// ««-------------- ≪ °◇◆◇° ≫ --------------»»
+
+bool Services::GetDeviceConfig(std::string& json_data, int& version, const std::string& device, const unsigned int timeout){
 
   json_data="";
   
   const std::string& name = (device=="") ? m_name : device;
   
-  std::string cmd_string = "{ \"device\":\""+ name +"\""
-                         + ", \"version\":"+std::to_string(version) + "}";
+  std::string cmd_string = "SELECT row_to_json(data) FROM device_config WHERE name='"+name+"' AND version="+std::to_string(version);
   
   std::string err="";
   
@@ -251,8 +478,7 @@ bool Services::GetDeviceConfig(std::string& json_data, const int version, const 
     return false;
   }
   
-  // response format '{"version":X, "data":"<contents>"}' - strip out contents
-  if(json_data.length()==0){
+  if(json_data.empty()){
     // if we got an empty response but the command succeeded,
     // the query worked but matched no records - run config not found
     err = "GetDeviceConfig error: config for device "+name+" version "+std::to_string(version)+" not found";
@@ -260,16 +486,15 @@ bool Services::GetDeviceConfig(std::string& json_data, const int version, const 
     json_data = err;
     return false;
   }
+  
+  // response format '{"data":"<contents>"}' - strip out contents
   Store tmp;
   tmp.JsonParser(json_data);
-  int tmp_version;
-  bool ok = tmp.Get("version",tmp_version);
-  if(ok){
-    //version = tmp_version;  // cannot pass back... without a more complex signature
-    ok = tmp.Get("data", json_data);
-  }
+  bool ok = tmp.Get("data", json_data);
   if(!ok){
-    std::clog<<"GetDeviceConfig error: invalid response: '"<<json_data<<"'"<<std::endl;
+    err = "GetDeviceConfig error: invalid response: '"+json_data+"'";
+    std::clog<<err<<std::endl;
+    json_data = err;
     return false;
   }
   
@@ -277,17 +502,28 @@ bool Services::GetDeviceConfig(std::string& json_data, const int version, const 
   
 }
 
+// ««-------------- ≪ °◇◆◇° ≫ --------------»»
+
 // get a run configuration via configuration ID
 bool Services::GetRunConfig(std::string& json_data, const int config_id, const unsigned int timeout){
 
   json_data="";
   
-  std::string cmd_string = "{ \"config_id\":"+std::to_string(config_id) + "}";
+  std::string cmd_string = "SELECT row_to_json(data) FROM run_config WHERE config_id="+std::to_string(config_id);
   
   std::string err="";
   
   if(!m_backend_client.SendCommand("R_RUNCONFIG", cmd_string, &json_data, &timeout, &err)){
     std::clog<<"GetRunConfig error: "<<err<<std::endl;
+    json_data = err;
+    return false;
+  }
+  
+  if(json_data.empty()){
+    // if we got an empty response but the command succeeded,
+    // the query worked but matched no records - run config not found
+    err = "GetRunConfig error: config_id "+std::to_string(config_id)+" not found";
+    std::clog<<err<<std::endl;
     json_data = err;
     return false;
   }
@@ -296,46 +532,6 @@ bool Services::GetRunConfig(std::string& json_data, const int config_id, const u
   Store tmp;
   tmp.JsonParser(json_data);
   bool ok = tmp.Get("data", json_data);
-  if(!ok){
-    std::clog<<"GetRunConfig error: invalid response: '"<<json_data<<"'"<<std::endl;
-    return false;
-  }
-  
-  return true;
-  
-}
-
-// get a run configuration by name and version (e.g. name: AmBe, version: 3)
-bool Services::GetRunConfig(std::string& json_data, const std::string& name, const int version, const unsigned int timeout){
-
-  json_data="";
-  
-  std::string cmd_string = "{ \"name\":\""+ name +"\""
-                         + ", \"version\":"+std::to_string(version) + "}";
-  
-  std::string err="";
-  
-  if(!m_backend_client.SendCommand("R_RUNCONFIG", cmd_string, &json_data, &timeout, &err)){
-    std::clog<<"GetRunConfig error: "<<err<<std::endl;
-    json_data = err;
-    return false;
-  }
-  
-  // response format '{"version":X, "data":"<contents>"}' - strip out contents
-  if(json_data.length()==0){
-    // if we got an empty response but the command succeeded,
-    // the query worked but matched no records - run config not found
-    std::clog<<"GetRunConfig error: config "<<name<<" version "<<version<<" not found"<<std::endl;
-    return false;
-  }
-  Store tmp;
-  tmp.JsonParser(json_data);
-  int tmp_version;
-  bool ok = tmp.Get("version",tmp_version);
-  if(ok){
-    //version = tmp_version;  // cannot pass back
-    ok = tmp.Get("data", json_data);
-  }
   if(!ok){
     err="GetRunConfig error: invalid response: '"+json_data+"'";
     std::clog<<err<<std::endl;
@@ -347,138 +543,183 @@ bool Services::GetRunConfig(std::string& json_data, const std::string& name, con
   
 }
 
-// quick aside for a couple of convenience wrappers.
-// For a device to get its configuration from a *run* configuration ID, it needs to:
-// 1. get the run configuration JSON from that ID (this represents a map of devices to device config IDs)
-// 2. extract its device configuration ID from this map
-// 3. get its device configuration from the database via this device configuration ID.
-// to make things easy for end users, provide a wrapper that does this.
-// technically we have two wrappers as there are two ways to specify a run configuration (by id or by name+version)
+// ««-------------- ≪ °◇◆◇° ≫ --------------»»
 
+// get a run configuration by name and version (e.g. name: AmBe, version: 3)
+bool Services::GetRunConfig(std::string& json_data, const std::string& name, const int version, const unsigned int timeout){
+
+  json_data="";
+  
+  std::string cmd_string = "SELECT row_to_json(data) FROM run_config WHERE name='"+name+"' AND version="+std::to_string(version);
+  
+  std::string err="";
+  
+  if(!m_backend_client.SendCommand("R_RUNCONFIG", cmd_string, &json_data, &timeout, &err)){
+    std::clog<<"GetRunConfig error: "<<err<<std::endl;
+    json_data = err;
+    return false;
+  }
+  
+  if(json_data.empty()){
+    // if we got an empty response but the command succeeded,
+    // the query worked but matched no records - run config not found
+    err = "GetRunConfig error: config "+name+" version "+std::to_string(version)+" not found";
+    std::clog<<err<<std::endl;
+    json_data = err;
+    return false;
+  }
+  
+  // response format '{"data":"<contents>"}' - strip out contents
+  Store tmp;
+  tmp.JsonParser(json_data);
+  bool ok = tmp.Get("data", json_data);
+  if(!ok){
+    err="GetRunConfig error: invalid response: '"+json_data+"'";
+    std::clog<<err<<std::endl;
+    json_data=err;
+    return false;
+  }
+  
+  return true;
+  
+}
+
+// ««-------------- ≪ °◇◆◇° ≫ --------------»»
+
+// Get a device configuration from a *run* configuration ID
 bool Services::GetRunDeviceConfig(std::string& json_data, const int runconfig_id, const std::string& device, int* version, unsigned int timeout){
   
   json_data="";
   
   const std::string& name = (device=="") ? m_name : device;
   
-  // 1. get the run configuration
-  std::string run_config="";
-  bool get_ok = GetRunConfig(run_config, runconfig_id, timeout/2);
+  std::string cmd_string = "SELECT row_to_json(data, version) FROM device_config WHERE name='"+name+"' AND version=(SELECT data->>'"+name+"' FROM run_config WHERE config_id="+std::to_string(runconfig_id)+")";
   
-  if(!get_ok){
-    // redundant as GetRunConfig prints the error - but is this still useful as calling context?
-    // TODO we should be using exceptions, of course
-    //std::clog<<"GetRunDeviceConfig error getting run config id "<<runconfig_id<<": '"<<run_config<<"'"<<std::endl;
-    json_data=run_config;
+  std::string err="";
+  
+  if(!m_backend_client.SendCommand("R_DEVCONFIG", cmd_string, &json_data, &timeout, &err)){
+    std::clog<<"GetRunDeviceConfig error: "<<err<<std::endl;
+    json_data = err;
     return false;
   }
   
-  // 2. extract the device's configuration id
-  Store tmp;
-  tmp.JsonParser(run_config);
-  int device_config_id;
-  get_ok = tmp.Get(name, device_config_id);
-  
-  if(!get_ok){
-    std::string err= "GetRunDeviceConfig error getting device config; device '"+name
-                   +"' not found in run configuration '"+run_config+"'";
+  if(json_data.empty()){
+    // if we got an empty response but the command succeeded,
+    // the query worked but matched no records - run config not found
+    err = "GetRunDeviceConfig error: config "+name+" for runconfig "+std::to_string(runconfig_id)+" not found"
     std::clog<<err<<std::endl;
     json_data = err;
     return false;
   }
-  if(version!=nullptr) *version=device_config_id;
   
-  // 3. use the device config id to get the device configuration
-  return GetDeviceConfig(json_data, device_config_id, name, timeout/2);
+  // response format '{"version": X, "data":"<contents>"}' - strip out contents
+  Store tmp;
+  tmp.JsonParser(json_data);
+  int tmp_version;
+  bool ok = tmp.Get("version",tmp_version);
+  if(ok && version){
+    *version = tmp_version;
+  }
+  ok = ok && tmp.Get("data", json_data);
+  if(!ok){
+    err="GetRunDeviceConfig error: invalid response: '"+json_data+"'";
+    std::clog<<err<<std::endl;
+    json_data=err;
+    return false;
+  }
+  
+  return true;
   
 }
 
-// second convenience wrapper
+// ««-------------- ≪ °◇◆◇° ≫ --------------»»
+
+// Get a device configuration from a *run* type name and version number
 bool Services::GetRunDeviceConfig(std::string& json_data, const std::string& runconfig_name, const int runconfig_version, const std::string& device, int* version, unsigned int timeout){
   
   json_data="";
   
   const std::string& name = (device=="") ? m_name : device;
   
-  // 1. get the run configuration
-  std::string run_config="";
-  bool get_ok = GetRunConfig(run_config, runconfig_name, runconfig_version, timeout/2);
+    std::string cmd_string = "SELECT row_to_json(data, version) FROM device_config WHERE name='"+name+"' AND version=(SELECT data->>'"+name+"' FROM run_config WHERE name='"+runconfig_name+"' AND version="+std::to_string(runconfig_version)+")";
   
-  if(!get_ok){
-    // redundant as GetRunConfig prints the error - but is this still useful as calling context?
-    // TODO we should be using exceptions, of course
-    //std::clog<<"GetRunDeviceConfig error getting run config '"<<runconfig_name<<"' version "
-    //         <<runconfig_version<<": '"<<run_config<<"'"<<std::endl;
-    json_data = run_config;
+  std::string err="";
+  
+  if(!m_backend_client.SendCommand("R_DEVCONFIG", cmd_string, &json_data, &timeout, &err)){
+    std::clog<<"GetRunDeviceConfig error: "<<err<<std::endl;
+    json_data = err;
     return false;
   }
   
-  // 2. extract the device's configuration id
-  Store tmp;
-  tmp.JsonParser(run_config);
-  int device_config_id;
-  get_ok = tmp.Get(name, device_config_id);
-  
-  if(!get_ok){
-    std::string err= "GetRunDeviceConfig error getting device config; device '"+name
-                   +"' not found in run configuration '"+run_config+"'";
+  if(json_data.empty()){
+    // if we got an empty response but the command succeeded,
+    // the query worked but matched no records - run config not found
+    err = "GetRunDeviceConfig error: config "+name+" for runconfig "+runconfig_name+" version "+std::to_string(runconfig_version)+" not found";
     std::clog<<err<<std::endl;
     json_data = err;
     return false;
   }
-  if(version!=nullptr) *version=device_config_id;
   
-  // 3. use the device config id to get the device configuration
-  return GetDeviceConfig(json_data, device_config_id, name, timeout/2);
+  // response format '{"version":X, "data":"<contents>"}' - strip out contents
+  Store tmp;
+  tmp.JsonParser(json_data);
+  int tmp_version;
+  bool ok = tmp.Get("version",tmp_version);
+  if(ok && version){
+    *version = tmp_version;
+  }
+  ok = ok && tmp.Get("data", json_data);
+  if(!ok){
+    err="GetRunDeviceConfig error: invalid response: '"+json_data+"'";
+    std::clog<<err<<std::endl;
+    json_data=err;
+    return false;
+  }
+  
+  return true;
   
 }
 
-// end convenience wrappers
+// ««-------------- ≪ °◇◆◇° ≫ --------------»»
 
 bool Services::GetROOTplot(const std::string& plot_name, int& version, std::string& draw_options, std::string& json_data, std::string* timestamp, const unsigned int timeout){
   
-  std::string cmd_string = "{ \"plot_name\":\""+ plot_name + "\""
-                         + ", \"version\":" + std::to_string(version)+ "}";
+  std::string cmd_string;
+  
+  if(version<0){
+    cmd_string = "SELECT row_to_json(version, time, data, draw_options), FROM rootplots WHERE name='"+plot_name+"' AND version="+std::to_string(version);
+  } else {
+    // https://stackoverflow.com/questions/tagged/greatest-n-per-group for faster
+    cmd_string = "SELECT row_to_json(version, time, data, draw_options) FROM rootplots WHERE name='"+plot_name+"' ORDER BY version DESC LIMIT 1";
+  }
   
   std::string err="";
   std::string response="";
-  if(!m_backend_client.SendCommand("R_ROOTPLOT", cmd_string, &response, &timeout, &err)){
+  
+  if(!m_backend_client.SendCommand("R_TROOTPLOT", cmd_string, &response, &timeout, &err)){
     std::clog<<"GetROOTplot error: "<<err<<std::endl;
     json_data = err;
     return false;
   }
   
   if(response.empty()){
-    std::clog<<"GetROOTplot error: empty response, "<<err<<std::endl;
+    err = "GetROOTplot error: ROOTplot "+plot_name+" version "+std::to_string(version)+" not found";
     json_data = err;
     return false;
   }
   
-  // response format '{"draw_options":"<options>", "timestamp":<value>, "version": <value>, "data":"<contents>"}'
-  size_t pos1=0, pos2=0;
-  std::string key;
-  std::map<std::string,std::string> vals;
-  while(true){
-    pos1=response.find('"',pos2);
-    if(pos1==std::string::npos) break;
-    pos2=response.find('"',++pos1);
-    if(pos2==std::string::npos) break;
-    std::string str = response.substr(pos1,(pos2-pos1));
-    ++pos2;
-    if(key.empty()){ key = str; }
-    else if(key=="data"){ break; }
-    else { vals[key] = str; key=""; }
-  }
-  vals[key] = response.substr(pos1,response.find_last_of('"')-pos1);
+  Store plot;
+  plot.JsonParser(response);
   
-  try{
-    draw_options = vals["draw_options"];
-    if(timestamp) *timestamp = vals["timestamp"];
-    version = std::stoi(vals["version"]);
-    json_data = vals["data"];
-  } catch(...){
-    std::clog<<"GetROOTplot error: failed to parse response '"<<response<<"'"<<std::endl;
-    json_data = "Parse error";
+  bool ok = plot.Get("data", json_data);
+  ok = ok && plot.Get("draw_options", draw_options);
+  ok = ok && plot.Get("version", version);
+  if(timestamp && ok) ok = ok && plot.Get("time", *timestamp);
+  
+  if(!ok){
+    err="GetROOTplot error: invalid response: '"+response+"'";
+    std::clog<<err<<std::endl;
+    json_data=err;
     return false;
   }
   
@@ -492,65 +733,71 @@ bool Services::GetROOTplot(const std::string& plot_name, int& version, std::stri
   
 }
 
-bool Services::SQLQuery(const std::string& database, const std::string& query, std::vector<std::string>& responses, const unsigned int timeout){
+// Get a device configuration from a *run* configuration ID
+
+bool Services::GetPlotlyPlot(
+    const std::string& name,
+    int&               version,
+    std::string&       trace,
+    std::string&       layout,
+    std::string*       timestamp,
+    unsigned int       timeout
+) {
   
-  responses.clear();
+  std::string cmd_string;
+  if(version<0){
+    cmd_string = "SELECT row_to_json(version, time, data, layout), FROM plotlyplots WHERE name='"+name+"' AND version="+std::to_string(version);
+  } else {
+    // https://stackoverflow.com/questions/tagged/greatest-n-per-group for faster
+    cmd_string = "SELECT row_to_json(version, time, data, layout) FROM plotlyplots WHERE name='"+name+"' ORDER BY version DESC LIMIT 1";
+  }
   
-  const std::string& db = (database=="") ? m_dbname : database;
+  std::string err;
+  std::string response;
+  if (!m_backend_client.SendCommand("R_PLOTLYPLOT", cmd_string, &response, &timeout, &err)){
+    std::clog << "GetPlotlyPlot error: " << err << std::endl;
+    json_data = err;
+    return false;
+  };
   
-  const std::string command = "{ \"database\":\""+db+"\""
-                            + ", \"query\":\""+ query+"\" }";
+  if(response.empty()){
+    err = "GetPlotlyPlot error: PlotlyPlot "+name+" version "+std::to_string(version)+" not found";
+    json_data = err;
+    return false;
+  }
   
-  std::string err="";
+  Store plot;
+  plot.JsonParser(response);
   
-  if(!m_backend_client.SendCommand("R_QUERY", command, &responses, &timeout, &err)){
-    std::clog<<"SQLQuery error: "<<err<<std::endl;
-    responses.resize(1);
-    responses.front() = err;
+  trace   = plot.Get<std::string>("data");
+  layout  = plot.Get<std::string>("layout");
+  version = plot.Get<int>("version");
+  
+  bool ok = plot.Get("data", trace);
+  ok = ok && plot.Get("layout", layout);
+  ok = ok && plot.Get("version", version);
+  if(timestamp && ok) ok = ok && plot.Get("time", *timestamp);
+  
+  if(!ok){
+    err="GetPlotlyPlot error: invalid response: '"+response+"'";
+    std::clog<<err<<std::endl;
+    json_data=err;
     return false;
   }
   
   return true;
-  
 }
 
-bool Services::SQLQuery(const std::string& database, const std::string& query, std::string& response, const unsigned int timeout){
-  
-  response="";
-  
-  const std::string& db = (database=="") ? m_dbname : database;
-  
-  std::vector<std::string> responses;
-  
-  bool ok = SQLQuery(db, query, responses, timeout);
-  
-  if(responses.size()!=0){
-    response = responses.front();
-    if(responses.size()>1){
-      std::clog<<"Warning: SQLQuery returned multiple rows, only first returned"<<std::endl;
-    }
-  }
-  
-  return ok;
-}
-
-// for things like insertions, the user may not have any return they care about
-bool Services::SQLQuery(const std::string& database, const std::string& query, const unsigned int timeout){
-  
-  std::string tmp;
-  return SQLQuery(database, query, tmp, timeout);
-
-}
 
 // ===========================================================================
 // Multicast Senders
 // -----------------
 
-bool Services::SendLog(const std::string& message, unsigned int severity, const std::string& device, unsigned int timestamp){
+bool Services::SendLog(const std::string& message, unsigned int severity, const std::string& device, const uint64_t timestamp){
   
   const std::string& name = (device=="") ? m_name : device;
   
-  std::string cmd_string = std::string{"{ \"topic\":\"logging\""}
+  std::string cmd_string = std::string{"{ \"topic\":\"LOGGING\""}
                          + ",\"time\":"+std::to_string(timestamp)
                          + ",\"device\":\""+ name +"\""
                          + ",\"severity\":"+std::to_string(severity)
@@ -573,11 +820,11 @@ bool Services::SendLog(const std::string& message, unsigned int severity, const 
 }
 
 
-bool Services::SendMonitoringData(const std::string& json_data, const std::string& subject, const std::string& device, unsigned int timestamp){
+bool Services::SendMonitoringData(const std::string& json_data, const std::string& subject, const std::string& device, const uint64_t timestamp){
   
   const std::string& name = (device=="") ? m_name : device;
   
-  std::string cmd_string = std::string{"{ \"topic\":\"monitoring\""}
+  std::string cmd_string = std::string{"{ \"topic\":\"MONITORING\""}
                          + ", \"time\":"+std::to_string(timestamp)
                          + ", \"device\":\""+ name +"\""
                          + ", \"subject\":\""+ subject +"\""
@@ -599,55 +846,12 @@ bool Services::SendMonitoringData(const std::string& json_data, const std::strin
   
 }
 
-// wrapper to send a root plot either to a temporary table or a persistent one
-bool Services::SendROOTplot(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, bool persistent, int* version, const unsigned int timestamp, const unsigned int timeout){
-  if(!persistent) return SendTemporaryROOTplot(plot_name, draw_options, json_data, version, timestamp);
-  return SendPersistentROOTplot(plot_name, draw_options, json_data, version, timestamp, timeout);
-}
-
-// send to persistent table over TCP
-bool Services::SendPersistentROOTplot(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, int* version, const unsigned int timestamp, const unsigned int timeout){
+// send ROOT plot over multicast
+bool Services::SendROOTplotMulticast(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, const uint64_t timestamp){
   
-  std::string cmd_string = "{ \"time\":"+std::to_string(timestamp)
-                         + ", \"plot_name\":\""+ plot_name +"\""
-                         + ", \"draw_options\":\""+ draw_options +"\""
-                         + ", \"data\":\""+ json_data+"\" }";
-  
-  std::string err="";
-  std::string response="";
-  
-  if(!m_backend_client.SendCommand("W_ROOTPLOT", cmd_string, &response, &timeout, &err)){
-    std::clog<<"SendROOTplot error: "<<err<<std::endl;
-    return false;
-  }
-  
-  // response is json with the version number of the created plot entry
-  // e.g. '{"version":3}'. check this is what we got, as validation.
-  if(response.length()>12){
-    // FIXME change to Store parsing so we can check this is the right key
-    response.replace(0,response.find_first_of(':')+1,"");
-    response.replace(response.find_last_of('}'),std::string::npos,"");
-    try {
-      if(version) *version = std::stoi(response);
-    } catch (...){
-      std::clog<<"SendROOTplot error: invalid response '"<<response<<"'"<<std::endl;
-      return false;
-    }
-  } else {
-    std::clog<<"SendROOTplot error: invalid response: '"<<response<<"'"<<std::endl;
-    return false;
-  }
-  
-  return true;
-  
-}
-
-// send to temporary table over multicast
-bool Services::SendTemporaryROOTplot(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, int* version, const unsigned int timestamp){
-  
-  std::string cmd_string = std::string{"{ \"topic\":\"rootplot\""}
+  std::string cmd_string = std::string{"{ \"topic\":\"TROOTPLOT\""}
                          + ", \"time\":"+std::to_string(timestamp)
-                         + ", \"plot_name\":\""+ plot_name +"\""
+                         + ", \"name\":\""+ plot_name +"\""
                          + ", \"draw_options\":\""+ draw_options +"\""
                          + ", \"data\":\""+ json_data+"\" }";
   
@@ -665,97 +869,6 @@ bool Services::SendTemporaryROOTplot(const std::string& plot_name, const std::st
   
   return true;
   
-}
-
-bool Services::GetPlotlyPlot(
-    const std::string& name,
-    int&               version,
-    std::string&       trace,
-    std::string&       layout,
-    unsigned int*      timestamp,
-    unsigned int       timeout
-) {
-  Store cmd;
-  cmd.Set("name", name);
-  if (version >= 0) cmd.Set("version", version);
-
-  std::string cmd_string;
-  cmd >> cmd_string;
-
-  std::string err;
-  std::string response;
-  if (!m_backend_client.SendCommand(
-        "R_PLOTLYPLOT", cmd_string, &response, &timeout, &err
-      ))
-  {
-    std::clog << "GetPlotlyPlot error: " << err << std::endl;
-    return false;
-  };
-
-  Store plot;
-  plot.JsonParser(response);
-
-  trace   = plot.Get<std::string>("trace");
-  layout  = plot.Get<std::string>("layout");
-  version = plot.Get<int>("version");
-  if (timestamp) *timestamp = plot.Get<int>("time");
-
-  return true;
-}
-
-bool Services::SendPlotlyPlot(
-    const std::string& name,
-    const std::string& trace,
-    const std::string& layout,
-    int*               version,
-    unsigned int       timestamp,
-    unsigned int       timeout
-) {
-  return SendPlotlyPlot(
-      name,
-      std::vector<std::string> { trace },
-      layout,
-      version,
-      timestamp,
-      timeout
-  );
-}
-
-bool Services::SendPlotlyPlot(
-    const std::string&              name,
-    const std::vector<std::string>& traces,
-    const std::string&              layout,
-    int*                            version,
-    unsigned int                    timestamp,
-    unsigned int                    timeout
-) {
-  std::stringstream ss;
-  ss
-    << "{\"name\":\"" << name
-    << "\",\"layout\":" << layout;
-  if (version) ss << ",\"version\":" << *version;
-  if (timestamp) ss << ",\"timestamp\":" << timestamp;
-  ss << ",\"traces\":[";
-  bool first = true;
-  for (auto& trace : traces) {
-    if (first)
-      first = false;
-    else
-      ss << ',';
-    ss << trace;
-  };
-  ss << "]}";
-
-  std::string err;
-  if (!m_backend_client.SendCommand(
-        "W_PLOTLYPLOT", ss.str(), static_cast<std::string*>(nullptr), &timeout, &err
-     ))
-  {
-    std::clog << "SendPlotlyPlot error: " << err << std::endl;
-    return false;
-  };
-
-  return true;
 }
 
 // ===========================================================================

--- a/src/ServiceDiscovery/Services.h
+++ b/src/ServiceDiscovery/Services.h
@@ -44,14 +44,19 @@ namespace ToolFramework {
     bool GetDeviceConfig(std::string& json_data, const int version=-1, const std::string& device="", const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     bool GetRunConfig(std::string& json_data, const int config_id, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     bool GetRunConfig(std::string& json_data, const std::string& name, const int version=-1, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool GetRunDeviceConfig(std::string& json_data, const int runconfig_id, const std::string& device="", /*int* version=nullptr,*/ const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool GetRunDeviceConfig(std::string& json_data, const std::string& runconfig_name, const int runconfig_version=-1, const std::string& device="", /*int* version=nullptr, */ const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool SendROOTplotZmq(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, const unsigned int keep_until=0, int* version=nullptr, const uint64_t timestamp=0, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool SendROOTplotMulticast(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, const uint64_t timestamp=SERVICES_DEFAULT_TIMEOUT);
-    bool GetROOTplot(const std::string& plot_name, int& version, std::string& draw_option, std::string& json_data, std::string* timestamp=nullptr, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool SendPlotlyPlot(const std::string& name, const std::string& json_trace, const std::string& json_layout="{}", int* version=nullptr, uint64_t timestamp=0, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool SendPlotlyPlot(const std::string& name, const std::vector<std::string>& json_traces, const std::string& json_layout="{}", int* version=nullptr, uint64_t timestamp=0, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool GetPlotlyPlot(const std::string& name, int& version, std::string& json_trace, std::string& json_layout, std::string* timestamp=nullptr, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool GetRunDeviceConfig(std::string& json_data, const int runconfig_id, const std::string& device="", int* version=nullptr, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool GetRunDeviceConfig(std::string& json_data, const std::string& runconfig_name, const int runconfig_version=-1, const std::string& device="", int* version=nullptr, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    // FIXME is default lifetime 5 ok?
+    bool SendROOTplotZmq(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, int* version=nullptr, const uint64_t timestamp=0, const unsigned int lifetime=5, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    // FIXME is default lifetime 5 ok?
+    bool SendROOTplotMulticast(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, const unsigned int lifetime=5, const uint64_t timestamp=SERVICES_DEFAULT_TIMEOUT);
+    bool GetROOTplot(const std::string& plot_name, int& version, std::string& draw_option, std::string& json_data, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    // FIXME is default lifetime 5 ok?
+    bool SendPlotlyPlot(const std::string& name, const std::string& json_trace, const std::string& json_layout="{}", int* version=nullptr, uint64_t timestamp=0, const unsigned int lifetime=5, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    // FIXME is default lifetime 5 ok?
+    bool SendPlotlyPlot(const std::string& name, const std::vector<std::string>& json_traces, const std::string& json_layout="{}", int* version=nullptr, uint64_t timestamp=0, const unsigned int lifetime=5, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool GetPlotlyPlot(const std::string& name, int& version, std::string& json_trace, std::string& json_layout, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    std::string TimeStringFromUnixMs(const uint64_t time);
     
     SlowControlCollection* GetSlowControlCollection();
     SlowControlElement* GetSlowControlVariable(std::string key);

--- a/src/ServiceDiscovery/Services.h
+++ b/src/ServiceDiscovery/Services.h
@@ -38,7 +38,8 @@ namespace ToolFramework {
     bool SendAlarm(const std::string& message, unsigned int level=0, const std::string& device="", const uint64_t timestamp=0, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     bool SendMonitoringData(const std::string& json_data, const std::string& subject, const std::string& device="", uint64_t timestamp=0);
     bool SendCalibrationData(const std::string& json_data, const std::string& description, const std::string& device="", uint64_t timestamp=0, int* version=nullptr, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool GetCalibrationData(std::string& json_data, int version=-1, const std::string& device="", const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool GetCalibrationData(std::string& json_data, int& version, const std::string& device="", const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool GetCalibrationData(std::string& json_data, int&& version=-1, const std::string& device="", const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     bool SendDeviceConfig(const std::string& json_data, const std::string& author, const std::string& description, const std::string& device="", uint64_t timestamp=0, int* version=nullptr, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     bool SendRunConfig(const std::string& json_data, const std::string& name, const std::string& author, const std::string& description, uint64_t timestamp=0, int* version=nullptr, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     bool GetDeviceConfig(std::string& json_data, const int version=-1, const std::string& device="", const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
@@ -50,12 +51,14 @@ namespace ToolFramework {
     bool SendROOTplotZmq(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, int* version=nullptr, const uint64_t timestamp=0, const unsigned int lifetime=5, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     // FIXME is default lifetime 5 ok?
     bool SendROOTplotMulticast(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, const unsigned int lifetime=5, const uint64_t timestamp=SERVICES_DEFAULT_TIMEOUT);
-    bool GetROOTplot(const std::string& plot_name, int& version, std::string& draw_option, std::string& json_data, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool GetROOTplot(const std::string& plot_name, std::string& draw_option, std::string& json_data, int& version, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool GetROOTplot(const std::string& plot_name, std::string& draw_option, std::string& json_data, int&& version=-1, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     // FIXME is default lifetime 5 ok?
     bool SendPlotlyPlot(const std::string& name, const std::string& json_trace, const std::string& json_layout="{}", int* version=nullptr, uint64_t timestamp=0, const unsigned int lifetime=5, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     // FIXME is default lifetime 5 ok?
     bool SendPlotlyPlot(const std::string& name, const std::vector<std::string>& json_traces, const std::string& json_layout="{}", int* version=nullptr, uint64_t timestamp=0, const unsigned int lifetime=5, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool GetPlotlyPlot(const std::string& name, int& version, std::string& json_trace, std::string& json_layout, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool GetPlotlyPlot(const std::string& name, std::string& json_trace, std::string& json_layout, int& version, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool GetPlotlyPlot(const std::string& name, std::string& json_trace, std::string& json_layout, int&& version=-1, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     std::string TimeStringFromUnixMs(const uint64_t time);
     
     SlowControlCollection* GetSlowControlCollection();

--- a/src/ServiceDiscovery/Services.h
+++ b/src/ServiceDiscovery/Services.h
@@ -30,29 +30,28 @@ namespace ToolFramework {
     bool Init(Store &m_variables, zmq::context_t* context_in, SlowControlCollection* sc_vars_in, bool new_service=false);
     bool Ready(const unsigned int timeout=10000); // default service discovery broadcast period is 5s, middleman also checks intermittently, compound total time should be <10s...
     
-    bool SQLQuery(const std::string& database, const std::string& query, std::vector<std::string>& responses, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool SQLQuery(const std::string& database, const std::string& query, std::string& response, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool SQLQuery(const std::string& database, const std::string& query, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool SQLQuery(/*const std::string& database,*/ const std::string& query, std::vector<std::string>& responses, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool SQLQuery(/*const std::string& database,*/ const std::string& query, std::string& response, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool SQLQuery(/*const std::string& database,*/ const std::string& query, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     
-    bool SendLog(const std::string& message, unsigned int severity=2, const std::string& device="", const unsigned int timestamp=0);
-    bool SendAlarm(const std::string& message, unsigned int level=0, const std::string& device="", const unsigned int timestamp=0, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool SendMonitoringData(const std::string& json_data, const std::string& subject, const std::string& device="", unsigned int timestamp=0);
-    bool SendCalibrationData(const std::string& json_data, const std::string& description, const std::string& device="", unsigned int timestamp=0, int* version=nullptr, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool SendLog(const std::string& message, unsigned int severity=2, const std::string& device="", const uint64_t timestamp=0);
+    bool SendAlarm(const std::string& message, unsigned int level=0, const std::string& device="", const uint64_t timestamp=0, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool SendMonitoringData(const std::string& json_data, const std::string& subject, const std::string& device="", uint64_t timestamp=0);
+    bool SendCalibrationData(const std::string& json_data, const std::string& description, const std::string& device="", uint64_t timestamp=0, int* version=nullptr, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     bool GetCalibrationData(std::string& json_data, int version=-1, const std::string& device="", const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool SendDeviceConfig(const std::string& json_data, const std::string& author, const std::string& description, const std::string& device="", unsigned int timestamp=0, int* version=nullptr, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool SendRunConfig(const std::string& json_data, const std::string& name, const std::string& author, const std::string& description, unsigned int timestamp=0, int* version=nullptr, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool SendDeviceConfig(const std::string& json_data, const std::string& author, const std::string& description, const std::string& device="", uint64_t timestamp=0, int* version=nullptr, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool SendRunConfig(const std::string& json_data, const std::string& name, const std::string& author, const std::string& description, uint64_t timestamp=0, int* version=nullptr, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     bool GetDeviceConfig(std::string& json_data, const int version=-1, const std::string& device="", const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     bool GetRunConfig(std::string& json_data, const int config_id, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     bool GetRunConfig(std::string& json_data, const std::string& name, const int version=-1, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool GetRunDeviceConfig(std::string& json_data, const int runconfig_id, const std::string& device="", int* version=nullptr, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool GetRunDeviceConfig(std::string& json_data, const std::string& runconfig_name, const int runconfig_version=-1, const std::string& device="", int* version=nullptr, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool SendROOTplot(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, bool persistent=false, int* version=nullptr, const unsigned int timestamp=0, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool SendTemporaryROOTplot(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, int* version=nullptr, const unsigned int timestamp=0);
-    bool SendPersistentROOTplot(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, int* version=nullptr, const unsigned int timestamp=0, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool GetRunDeviceConfig(std::string& json_data, const int runconfig_id, const std::string& device="", /*int* version=nullptr,*/ const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool GetRunDeviceConfig(std::string& json_data, const std::string& runconfig_name, const int runconfig_version=-1, const std::string& device="", /*int* version=nullptr, */ const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool SendROOTplotZmq(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, const unsigned int keep_until=0, int* version=nullptr, const uint64_t timestamp=0, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool SendROOTplotMulticast(const std::string& plot_name, const std::string& draw_options, const std::string& json_data, const uint64_t timestamp=SERVICES_DEFAULT_TIMEOUT);
     bool GetROOTplot(const std::string& plot_name, int& version, std::string& draw_option, std::string& json_data, std::string* timestamp=nullptr, const unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool SendPlotlyPlot(const std::string& name, const std::string& json_trace, const std::string& json_layout="{}", int* version=nullptr, unsigned int timestamp=0, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool SendPlotlyPlot(const std::string& name, const std::vector<std::string>& json_traces, const std::string& json_layout="{}", int* version=nullptr, unsigned int timestamp=0, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
-    bool GetPlotlyPlot(const std::string& name, int& version, std::string& json_trace, std::string& json_layout, unsigned int* timestamp=nullptr, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool SendPlotlyPlot(const std::string& name, const std::string& json_trace, const std::string& json_layout="{}", int* version=nullptr, uint64_t timestamp=0, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool SendPlotlyPlot(const std::string& name, const std::vector<std::string>& json_traces, const std::string& json_layout="{}", int* version=nullptr, uint64_t timestamp=0, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
+    bool GetPlotlyPlot(const std::string& name, int& version, std::string& json_trace, std::string& json_layout, std::string* timestamp=nullptr, unsigned int timeout=SERVICES_DEFAULT_TIMEOUT);
     
     SlowControlCollection* GetSlowControlCollection();
     SlowControlElement* GetSlowControlVariable(std::string key);

--- a/src/ServiceDiscovery/ServicesBackend.cpp
+++ b/src/ServiceDiscovery/ServicesBackend.cpp
@@ -96,22 +96,22 @@ void ServicesBackend::SetUp(zmq::context_t* in_context, std::function<void(std::
 }
 
 bool ServicesBackend::Initialise(std::string configfile){
-
-  /*               Retrieve Configs            */
-  /* ----------------------------------------- */
-  
-  // configuration options can be parsed via a Store class
-  if(configfile!="") m_variables.Initialise(configfile);
-
-  return Initialise(m_variables);
-
+	
+	/*               Retrieve Configs            */
+	/* ----------------------------------------- */
+	
+	// configuration options can be parsed via a Store class
+	if(configfile!="") m_variables.Initialise(configfile);
+	
+	return Initialise(m_variables);
+	
 }
-  
-bool ServicesBackend::Initialise(Store &variables_in){
 
-  std::string tmp="";
-  variables_in>>tmp;
-  m_variables.JsonParser(tmp);
+bool ServicesBackend::Initialise(Store &variables_in){
+	
+	std::string tmp="";
+	variables_in>>tmp;
+	m_variables.JsonParser(tmp);
 	
 	/*            General Variables              */
 	/* ----------------------------------------- */
@@ -348,9 +348,13 @@ bool ServicesBackend::RegisterServices(){
 	// we can make our lives a little easier by using a Utilities class
 	utilities = new DAQUtilities(context);
 	
-	// we can now register the client sockets with the following:
-	utilities->AddService("slowcontrol_write", clt_pub_port);
-	utilities->AddService("slowcontrol_read",  clt_dlr_port);
+	// register our ports for advertisement
+	get_ok = utilities->AddPort("db_write", clt_pub_port);
+	get_ok = get_ok && utilities->AddPort("db_read",  clt_dlr_port);
+	if(!get_ok){
+		Log("Error advertising ports!",v_error,verbosity);
+		return false;
+	}
 	
 	return true;
 }
@@ -533,8 +537,8 @@ bool ServicesBackend::DoCommand(Command& cmd, uint32_t timeout_ms){
 	// submit a request to send our command.
 	std::promise<int> send_ticket;
 	std::future<int> send_receipt = send_ticket.get_future();
-	send_queue_mutex.lock();
 	if(verbosity>10) std::cout<<"ServicesBackend::DoCommand putting command into waiting-to-send list"<<std::endl;
+	send_queue_mutex.lock();
 	waiting_senders.emplace(cmd, std::move(send_ticket));
 	send_queue_mutex.unlock();
 	
@@ -787,8 +791,9 @@ bool ServicesBackend::Finalise(){
 	background_thread.join();
 	
 	Log("ServicesBackend Removing services",v_debug,verbosity);
-	if(utilities) utilities->RemoveService("slowcontrol_write");
-	if(utilities) utilities->RemoveService("slowcontrol_read");
+	//if(utilities) utilities->RemoveService("slowcontrol_write");
+	if(utilities) utilities->RemovePort("db_read");
+	if(utilities) utilities->RemovePort("db_write");
 	
 	Log("ServicesBackend Closing multicast socket",v_debug,verbosity);
 	close(log_socket);
@@ -964,6 +969,9 @@ bool ServicesBackend::Ready(int timeout){
 	// only poll dealer socket, pub sockets always return true immediately so ignore the timeout
 	// polling the input socket checks for a message, so don't do that.
 	int ret;
+//	printf("ServicesBackend waiting for up to %d ms for connection on read/rep socket\n",timeout);
+//	auto timeout_ms = std::chrono::milliseconds(timeout);
+//	std::chrono::time_point<std::chrono::steady_clock> start = std::chrono::steady_clock::now();
 	try {
 		dlr_socket_mutex.lock();
 		ret = zmq::poll(&out_polls.at(1), 1, timeout);
@@ -978,9 +986,12 @@ bool ServicesBackend::Ready(int timeout){
 		return false;
 	} else if(ret==0){
 		// 'resource temoprarily unavailable' - no-one connected.
+//		printf("ServicesBackend::Ready - no one connected (%s)\n", zmq_strerror(errno));
 	} else if(out_polls.at(1).revents & ZMQ_POLLOUT){
+//		printf("Connected!\n");
 		return true;
 	}
+//	printf("returning after %ld/%d ms\n", std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count(), timeout);
 	
 	return false;
 	

--- a/src/ServiceDiscovery/ServicesBackend.cpp
+++ b/src/ServiceDiscovery/ServicesBackend.cpp
@@ -2,9 +2,9 @@
 
 using namespace ToolFramework;
 
-Command::Command(std::string command_in, char type_in, std::string topic_in, const unsigned int timeout_ms_in){
+Command::Command(std::string command_in, char type_in, std::string topic_in, const uint32_t timeout_ms_in){
 	command = command_in;
-	type = type_in;
+	type = type_in; // TODO type is unnecessary, could just use topic[0]
 	topic=topic_in;
 	success=0;
 	response=std::vector<std::string>{};
@@ -421,12 +421,12 @@ bool ServicesBackend::SendMulticast(MulticastType type, std::string command, std
 	return true;
 }
 
-bool ServicesBackend::SendCommand(const std::string& topic, const std::string& command, std::vector<std::string>* results, const unsigned int* timeout_ms, std::string* err){
+bool ServicesBackend::SendCommand(const std::string& topic, const std::string& command, std::vector<std::string>* results, const uint32_t* timeout_ms, std::string* err){
 	// send a command and receive response.
 	// This is a wrapper that ensures we always return within the requested timeout.
 	if(verbosity>10) std::cout<<"ServicesBackend::SendCommand invoked with command '"<<command<<"'"<<std::endl;
 	
-	int timeout=command_timeout;            // default timeout for submission of command and receipt of response
+	uint32_t timeout=command_timeout;            // default timeout for submission of command and receipt of response
 	if(timeout_ms) timeout=*timeout_ms;     // override by user if a custom timeout is given
 	
 	// encapsulate the command in an object.
@@ -458,7 +458,7 @@ bool ServicesBackend::SendCommand(const std::string& topic, const std::string& c
 	// In fact it's useful to indicate a topic in all cases, even when the actual message will
 	// (for now) go over a dealer/router combination that cannot filter on the topic.
 	// forward the timeout to the Command (and thus zmq::poll in PollAndSend...) ... is this sensible? HMMMMM FIXME
-	Command cmd{command, type, topic.substr(2,std::string::npos),timeout};
+	Command cmd{command, type, topic,timeout};
 	
 	// wrap our attempt to get the response in try/catch, just in case?
 	try {
@@ -478,7 +478,7 @@ bool ServicesBackend::SendCommand(const std::string& topic, const std::string& c
 	return false;
 }
 
-bool ServicesBackend::SendCommand(const std::string& topic, const std::string& command, std::string* results, const unsigned int* timeout_ms, std::string* err){
+bool ServicesBackend::SendCommand(const std::string& topic, const std::string& command, std::string* results, const uint32_t* timeout_ms, std::string* err){
 	// wrapper for when user expects only one returned response part
 	if(err) *err="";
 	std::vector<std::string> resultsvec;
@@ -492,7 +492,7 @@ bool ServicesBackend::SendCommand(const std::string& topic, const std::string& c
 	return ret;
 }
 
-bool ServicesBackend::DoCommand(Command& cmd, int timeout_ms){
+bool ServicesBackend::DoCommand(Command& cmd, uint32_t timeout_ms){
 	if(verbosity>10) std::cout<<"ServicesBackend::DoCommand received command"<<std::endl;
 	// submit a command, wait for the response and return it
 	
@@ -549,10 +549,10 @@ bool ServicesBackend::DoCommand(Command& cmd, int timeout_ms){
 		// See how long that took to send, and subtract that from our total time allotment
 		// to see how long we have to wait for the response to arrive.
 		auto send_end = std::chrono::high_resolution_clock::now();
-		int send_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(send_end - send_start).count();
-		timeout_ms -= send_time_ms;
-		// juuuust in case, ensure our remaining time is not negative. :)
-		if(timeout_ms<0) timedout=true;
+		auto send_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(send_end - send_start).count();
+		// juuuust in case, make sure we actually still have time left to wait for the response
+		if(send_time_ms > timeout_ms) timedout=true; // shouldn't be possible really
+		else timeout_ms -= send_time_ms;
 	}
 	
 	// did we get a response in time?
@@ -898,7 +898,7 @@ bool ServicesBackend::Send(zmq::socket_t* sock, bool more, std::vector<std::stri
 	return send_ok;
 }
 
-int ServicesBackend::PollAndReceive(zmq::socket_t* sock, zmq::pollitem_t poll, int timeout, std::vector<zmq::message_t>& outputs){
+int ServicesBackend::PollAndReceive(zmq::socket_t* sock, zmq::pollitem_t poll, uint32_t timeout, std::vector<zmq::message_t>& outputs){
 	
 	// poll the input socket for messages
 	try {

--- a/src/ServiceDiscovery/ServicesBackend.cpp
+++ b/src/ServiceDiscovery/ServicesBackend.cpp
@@ -567,7 +567,7 @@ bool ServicesBackend::DoCommand(Command& cmd, uint32_t timeout_ms){
 		// sending timed out
 		if(cmd.type=='w') ++write_commands_failed;
 		else if(cmd.type=='r') ++read_commands_failed;
-		Log("Timed out sending command "+std::to_string(thismsgid),v_warning,verbosity);
+		Log("Timed out sending command "+std::to_string(thismsgid),v_error,verbosity);
 		cmd.success = false;
 		cmd.err = "Timed out sending command";
 		
@@ -618,7 +618,7 @@ bool ServicesBackend::DoCommand(Command& cmd, uint32_t timeout_ms){
 		// timed out
 		if(cmd.type=='w') ++write_commands_failed;
 		else if(cmd.type=='r') ++read_commands_failed;
-		Log("Timed out waiting for response for command "+std::to_string(thismsgid),v_warning,verbosity);
+		Log("Timed out waiting for response for command "+std::to_string(thismsgid),v_error,verbosity);
 		cmd.success = false;
 		cmd.err = "Timed out waiting for response";
 		return false;

--- a/src/ServiceDiscovery/ServicesBackend.cpp
+++ b/src/ServiceDiscovery/ServicesBackend.cpp
@@ -280,13 +280,15 @@ bool ServicesBackend::InitMulticast(){
 	/*              Multicast Setup              */
 	/* ----------------------------------------- */
 	
-	int log_port = 55554;
-	int mon_port = 55553;
-	std::string multicast_address = "239.192.1.1";
+	int log_port = 5000;
+	int mon_port = 5000;
+	std::string log_address = "239.192.1.2";
+	std::string mon_address = "239.192.1.3";
 	
 	m_variables.Get("log_port",log_port);
 	m_variables.Get("mon_port",mon_port);
-	m_variables.Get("multicast_address",multicast_address);
+	m_variables.Get("log_address",log_address);
+	m_variables.Get("mon_address",mon_address);
 	
 	// set up multicast socket for sending logging & monitoring data
 	log_socket = socket(AF_INET, SOCK_DGRAM, 0);
@@ -323,10 +325,10 @@ bool ServicesBackend::InitMulticast(){
 	mon_addr = log_addr;
 	mon_addr.sin_port = htons(mon_port);
 	// convert destination address string to binary
-	get_ok =           inet_aton(multicast_address.c_str(), &log_addr.sin_addr);
-	get_ok = get_ok && inet_aton(multicast_address.c_str(), &mon_addr.sin_addr);
+	get_ok =           inet_aton(log_address.c_str(), &log_addr.sin_addr);
+	get_ok = get_ok && inet_aton(mon_address.c_str(), &mon_addr.sin_addr);
 	if(get_ok==0){ // returns 0 on failure, not success
-		Log("Bad multicast address '"+multicast_address+"'",v_error,verbosity);
+		Log("Bad multicast address '"+log_address+"' or '"+mon_address+"'",v_error,verbosity);
 		return false;
 	}
 	multicast_addrlen = sizeof(log_addr);

--- a/src/ServiceDiscovery/ServicesBackend.h
+++ b/src/ServiceDiscovery/ServicesBackend.h
@@ -92,6 +92,9 @@ class ServicesBackend {
 	// multicast socket file descriptors
 	int log_socket=-1;
 	int mon_socket=-1;
+	// mutexes to lock them
+	std::mutex log_socket_mtx;
+	std::mutex mon_socket_mtx;
 	// multicast destination address structure
 	struct sockaddr_in log_addr;
 	struct sockaddr_in mon_addr;
@@ -103,7 +106,7 @@ class ServicesBackend {
 	std::map<uint32_t, std::promise<Command>> waiting_recipients;
 	
 	void Log(std::string msg, int msg_verb, int verbosity); //??  generalise private
-        bool InitZMQ(); //private
+	bool InitZMQ(); //private
 	bool InitMulticast(); // private
 	bool RegisterServices(); //private
 	// wrapper funtion; add command to outgoing queue, receive response. ~30s timeout.

--- a/src/ServiceDiscovery/ServicesBackend.h
+++ b/src/ServiceDiscovery/ServicesBackend.h
@@ -27,7 +27,7 @@
 namespace ToolFramework {
 
 struct Command {
-	Command(std::string command_in, char cmd_type_in, std::string topic_in, const unsigned int timeout_ms_in);
+	Command(std::string command_in, char cmd_type_in, std::string topic_in, const uint32_t timeout_ms_in);
 	
 	Command(const Command& cmd_in);  // copy constructor
 	Command(Command&& cmd_in);       // move constructor
@@ -60,8 +60,8 @@ class ServicesBackend {
 	bool Finalise();
 	
 	// interfaces called by clients. These return within timeout.
-	bool SendCommand(const std::string& topic, const std::string& command, std::vector<std::string>* results=nullptr, const unsigned int* timeout_ms=nullptr, std::string* err=nullptr);
-	bool SendCommand(const std::string& topic, const std::string& command, std::string* results=nullptr, const unsigned int* timeout_ms=nullptr, std::string* err=nullptr);
+	bool SendCommand(const std::string& topic, const std::string& command, std::vector<std::string>* results=nullptr, const uint32_t* timeout_ms=nullptr, std::string* err=nullptr);
+	bool SendCommand(const std::string& topic, const std::string& command, std::string* results=nullptr, const uint32_t* timeout_ms=nullptr, std::string* err=nullptr);
 	
 	// multicasts
 	bool SendMulticast(MulticastType type, std::string command, std::string* err=nullptr);
@@ -110,7 +110,7 @@ class ServicesBackend {
 	bool InitMulticast(); // private
 	bool RegisterServices(); //private
 	// wrapper funtion; add command to outgoing queue, receive response. ~30s timeout.
-	bool DoCommand(Command& cmd, int timeout_ms); //private
+	bool DoCommand(Command& cmd, uint32_t timeout_ms); //private
 	// actual send/receive functions
 	bool SendNextCommand(); //private
 	bool GetNextResponse(); //priavte
@@ -121,9 +121,9 @@ class ServicesBackend {
 	
 	// TODO add retrying
 	int max_retries;
-	int inpoll_timeout;
-	int outpoll_timeout;
-	int command_timeout;
+	uint32_t inpoll_timeout;
+	uint32_t outpoll_timeout;
+	uint32_t command_timeout;
 	
 	// TODO add stats reporting
 	boost::posix_time::time_duration resend_period;      // time between resends if not acknowledged
@@ -158,7 +158,7 @@ class ServicesBackend {
 	// zmq helper functions
 	// TODO move to separate class as these are shared by middleman
 	
-	int PollAndReceive(zmq::socket_t* sock, zmq::pollitem_t poll, int timeout, std::vector<zmq::message_t>& outputs);
+	int PollAndReceive(zmq::socket_t* sock, zmq::pollitem_t poll, uint32_t timeout, std::vector<zmq::message_t>& outputs);
 	bool Receive(zmq::socket_t* sock, std::vector<zmq::message_t>& outputs);
 	
 	// base cases; send single (final) message part
@@ -201,7 +201,7 @@ class ServicesBackend {
 	// wrapper to do polling if required
 	// version if one part
 	template <typename T>
-	int PollAndSend(zmq::socket_t* sock, zmq::pollitem_t poll, int timeout, T&& message){
+	int PollAndSend(zmq::socket_t* sock, zmq::pollitem_t poll, uint32_t timeout, T&& message){
 		if(verbosity>10) std::cout<<__PRETTY_FUNCTION__<<" called"<<std::endl;
 		int send_ok=0;
 		// check for listener
@@ -232,7 +232,7 @@ class ServicesBackend {
 	// wrapper to do polling if required
 	// version if more than one part
 	template <typename T, typename... Rest>
-	int PollAndSend(zmq::socket_t* sock, zmq::pollitem_t poll, int timeout, T&& message, Rest&&... rest){
+	int PollAndSend(zmq::socket_t* sock, zmq::pollitem_t poll, uint32_t timeout, T&& message, Rest&&... rest){
 		if(verbosity>10) std::cout<<__PRETTY_FUNCTION__<<" called"<<std::endl;
 		int send_ok = 0;
 		// check for listener

--- a/src/ServiceDiscovery/ServicesBackend.h
+++ b/src/ServiceDiscovery/ServicesBackend.h
@@ -14,6 +14,9 @@
 #include <queue>
 #include <future>
 #include <mutex>
+#include <atomic>
+#include <chrono>        // sleep_for / sleep_until
+#include <thread>        // this_thread
 #include <unistd.h>      // gethostname
 #include <locale>        // toupper/tolower
 #include <functional>    // std::function, std::negate
@@ -132,8 +135,8 @@ class ServicesBackend {
 	boost::posix_time::ptime last_read;                  // when we last sent a read command
 	boost::posix_time::ptime last_printout;              // when we last printed out stats about what we're doing
 	
-	int read_commands_failed;
-	int write_commands_failed;
+	std::atomic<int> read_commands_failed{0};
+	std::atomic<int> write_commands_failed{0};
 	
 	// general
 	int verbosity;
@@ -151,7 +154,7 @@ class ServicesBackend {
 	// since that's the one the middleman needs to know to send replies back
 	std::string clt_ID;
 	
-	uint32_t msg_id = 0;
+	std::atomic<uint32_t> msg_id{0};
 	
 	// =======================================================
 	

--- a/src/ServiceDiscovery/SlowControlElement.cpp
+++ b/src/ServiceDiscovery/SlowControlElement.cpp
@@ -202,10 +202,8 @@ bool SlowControlElement::SetDefault(std::string value){
 
 
 bool SlowControlElement::SetValue(const char value[]){
-  bool ret=false;
   std::string tmp_value=value;
-  ret=SetValue(tmp_value);
-  return ret;
+  return SetValue(tmp_value);
 }
 
 


### PR DESCRIPTION
* in ToolChainConfig templates, split multicast traffic between 3 addresses for ServiceDiscovery, Logging and Monitoring (239.192.1.1,2,3 respectively) but now by default using the same port (5000) although configurable
* in ServiceDiscovery::MulticastListenThread bind to the multicast address, not INADDR_ANY, as IP_ADD_MEMBERSHIP acts globally so is not sufficient to listen for only this source of traffic.
* set linger option on zmq sockets in ServiceDiscovery

Services class:
* fix use of magic number 655355 -> MAX_UDP_PACKET_SIZE
* convert timestamps from unix ms to time string locally, rather than in the middleman, for better accuracy
* SendAlarm populates 'alarm' field not 'message' field in database (previously field name was mapped in middleman)
* make topics 'LOGGING', 'MONITORING' uppercase for consistency
* SendCalibrationData, SendDeviceConfig, SendRunConfig no longer quote data field for updated middleman
* response format for insertions is no longer JSON '{"version": val}' and just 'val': update response handling
* Get functions (GetCalibrationData, GetDeviceConfig, GetRunConfig, GetRunDeviceConfig...) now send SQL, not JSON. Response and API returns are unchanged.
* GetRunDeviceConfig now works via a single query with subquery rather than two separate queries

ServicesBackend class:
* split logging and monitoring to different addresses
* replace AddService with AddPort, RemoveService with RemovePort for updated Utilities class - ports are now named 'db_read' and 'db_write'
* remove narrowing cast of timeout
* add mutex locking of socket in SendMulticast function in case calling application is multi-threaded
* change message id and failure tracking counters to atomics


API changes:
* fix type of timestamp arguments (unsigned int -> uint64_t)
* rename SendCalibrationData argument 'device' to 'name'
* SendTemporaryRootPlot and SendPersistentRootPlot are now SendRootPlotMulticast and SendRootPlotZmq. SendRootPlot defaults to the latter. SendPlotlyPlot always uses the latter.
* Send*Plot functions now take a lifetime stored in the database. Default lifetime is 5 versions.
* SQLQuery no longer accepts a database argument
* GetROOTplot no longer potentially optionally the timestamp of the associated plot.

N.B. 
backports required for old middleman:
* fix type of timestamp arguments (unsigned int -> uint64_t)