### PR TITLE
add 0-time poll after connect in UpdateConnections 

### DIFF
--- a/src/DAQDataModelBase/DAQUtilities.cpp
+++ b/src/DAQDataModelBase/DAQUtilities.cpp
@@ -136,6 +136,10 @@ int DAQUtilities::UpdateConnections(std::string ServiceName, zmq::socket_t* sock
       //service->Get("remote_port",port);
       tmp="tcp://"+ tmp;
       sock->connect(tmp.c_str());
+      // trigger pub sockets to immediately send their topic subscriptions, perhaps
+      zmq::pollitem_t tmppoll{*sock, 0, ZMQ_POLLIN, 0};
+      zmq::poll(&tmppoll, 1, 0);
+
     }
     else{
       delete service;


### PR DESCRIPTION
allegedly may trigger internal zmq 'ProcessEvents' function to send subscriptions to pub sockets. 
May help in preventing pub messages being lost.