### PR TITLE
replace stringstream zmq parsing with string construction so we don't rely on null terminated messages

### DIFF
--- a/UserTools/Logger/Logger.cpp
+++ b/UserTools/Logger/Logger.cpp
@@ -46,13 +46,13 @@ bool Logger::Execute(){
     zmq::message_t Rmessage;
     if(  LogReceiver->recv (&Rmessage)){
       // printf("got a message \n");
-      std::istringstream ss(static_cast<char*>(Rmessage.data()));
+      std::string ss(static_cast<char*>(Rmessage.data()),Rmessage.size());
       
-      *m_log<<ss.str()<<std::flush;
+      *m_log<<ss<<std::flush;
       
       Store bb;
       
-      bb.JsonParser(ss.str());
+      bb.JsonParser(ss);
       
       *m_log<<*(bb["msg_value"])<<std::flush;
     }

--- a/UserTools/template/MyToolZMQMultiThread.cpp
+++ b/UserTools/template/MyToolZMQMultiThread.cpp
@@ -75,8 +75,8 @@ bool MyToolZMQMultiThread::Execute(){
 
     zmq::message_t message;
     ManagerReceive->recv(&message);
-    std::istringstream iss(static_cast<char*>(message.data()));
-    *m_log<<"reply = "<<iss.str()<<std::endl;
+    std::string iss(static_cast<char*>(message.data()),message.size());
+    *m_log<<"reply = "<<iss<<std::endl;
     m_freethreads++;
 
   }
@@ -141,7 +141,7 @@ void MyToolZMQMultiThread::Thread(Thread_args* arg){
   
     zmq::message_t message;
     args->ThreadReceive->recv(&message);
-    std::istringstream iss(static_cast<char*>(message.data()));
+    std::string ss(static_cast<char*>(message.data()),message.size());
   
     sleep(10);
 

--- a/src/DAQDataModelBase/DAQUtilities.h
+++ b/src/DAQDataModelBase/DAQUtilities.h
@@ -119,7 +119,8 @@ namespace ToolFramework{
       
       if(sock->recv(&message)){   
 	
-	std::istringstream iss(static_cast<char*>(message.data()));
+	std::string ss(static_cast<char*>(message.data()),message.size());
+	std::istringstream iss(ss);
 	
 	//      long long unsigned int tmpP;
 	unsigned long tmpP;

--- a/src/DAQLogging/DAQLogging.cpp
+++ b/src/DAQLogging/DAQLogging.cpp
@@ -287,16 +287,16 @@ src/DAQLogging/DAQLogging.{h,cpp} -nw
 
      zmq::message_t Receive;
      LogReceiver.recv (&Receive);
-     std::istringstream ss(static_cast<char*>(Receive.data()));
+     std::string ss(static_cast<char*>(Receive.data()),Receive.size());
 
 
      if (logfile.is_open())
        {
-	 logfile << ss.str();//<<std::endl;
+	 logfile << ss;//<<std::endl;
       
        }
      
-     if(ss.str()=="Quit")running=false;
+     if(ss=="Quit")running=false;
    }
    std::cout<<"imclosing"<<std::endl;
    logfile.close();   
@@ -367,9 +367,9 @@ src/DAQLogging/DAQLogging.{h,cpp} -nw
         
        zmq::message_t Receive;
        if(LogReceiver.recv (&Receive)){
-	 std::istringstream ss(static_cast<char*>(Receive.data()));
+	 std::string ss(static_cast<char*>(Receive.data()),Receive.size());
 	 
-	 if(ss.str()=="Quit"){
+	 if(ss=="Quit"){
 	   //printf("%s \n","received quit");
 	   running=false;
 	 }
@@ -388,13 +388,13 @@ src/DAQLogging/DAQLogging.{h,cpp} -nw
 	   outmessage.Set("msg_id",msg_id);
 	   outmessage.Set("msg_time", isot.str());
 	   outmessage.Set("msg_type", "Log");
-	   outmessage.Set("msg_value",ss.str());
+	   outmessage.Set("msg_value",ss);
 	   */
 	   outmessage.Set("topic","logging");
 	   outmessage.Set("time", isot.str());
 	   outmessage.Set("device",args->m_service);
 	   outmessage.Set("severity","logging");
-	   outmessage.Set("message",ss.str());
+	   outmessage.Set("message",ss);
 	     
 	   std::string rmessage;
 	   outmessage>>rmessage;
@@ -459,7 +459,7 @@ src/DAQLogging/DAQLogging.{h,cpp} -nw
 
        zmq::message_t Receive;
        if(LogReceiver.recv (&Receive)){
-	 std::istringstream ss(static_cast<char*>(Receive.data()));
+	 std::string ss(static_cast<char*>(Receive.data()),Receive.size());
 
 
 	 boost::posix_time::ptime t = boost::posix_time::microsec_clock::universal_time();
@@ -474,7 +474,7 @@ src/DAQLogging/DAQLogging.{h,cpp} -nw
 	 outmessage.Set("msg_id",msg_id);
 	 *outmessage["msg_time"]=isot.str();
 	 *outmessage["msg_type"]="Log";
-	 outmessage.Set("msg_value",ss.str());
+	 outmessage.Set("msg_value",ss);
 
 
 	 for(std::map<std::string,zmq::socket_t*>::iterator it=RemoteConnections.begin(); it!=RemoteConnections.end(); ++it){
@@ -500,7 +500,7 @@ src/DAQLogging/DAQLogging.{h,cpp} -nw
 	 }
 	 
 	 
-	 if(ss.str()=="Quit"){
+	 if(ss=="Quit"){
 	   //printf("%s \n","received quit");
 	   running=false;
 	 }
@@ -536,7 +536,8 @@ src/DAQLogging/DAQLogging.{h,cpp} -nw
 	 //printf("sent sd req \n");	 
 	 zmq::message_t receive;
 	 if(Ireceive.recv(&receive)){
-	   std::istringstream iss(static_cast<char*>(receive.data()));
+	   std::string ss(static_cast<char*>(receive.data()),receive.size());
+	   std::istringstream iss(ss);
 	   //printf("received from sd \n");	   
 
 	   int size;
@@ -560,8 +561,8 @@ src/DAQLogging/DAQLogging.{h,cpp} -nw
 	     zmq::message_t servicem;
 	     Ireceive.recv(&servicem);
 	     
-	     std::istringstream ss(static_cast<char*>(servicem.data()));
-	     service->JsonParser(ss.str());
+	     std::string ss2(static_cast<char*>(servicem.data()),servicem.size());
+	     service->JsonParser(ss2);
 	     
 	     std::string servicetype;
 	     std::string uuid;

--- a/src/NodeDaemon/NodeDaemon.cpp
+++ b/src/NodeDaemon/NodeDaemon.cpp
@@ -140,11 +140,11 @@ int main(int argc, char* argv[]){
 
       direct.recv(&message);
       
-      std::istringstream iss(static_cast<char*>(message.data()));
-      //std::cout<<"Received message: "<<iss.str()<<std::endl;
+      std::string iss(static_cast<char*>(message.data()), message.size());
+      //std::cout<<"Received message: "<<iss<<std::endl;
       
       Store bb;
-      bb.JsonParser(iss.str());
+      bb.JsonParser(iss);
       
       
       std::string ret="Command not recognised (Use ? to find valid commands)";
@@ -193,7 +193,7 @@ int main(int argc, char* argv[]){
       
       else if(msg_value=="File"){
 	ret="Receiving file";
-	std::ofstream outfile (bb.Get<std::string>("var1").c_str());
+	std::ofstream outfile (bb.Get<std::string>("var1").c_str(), std::ios::binary);
 	if (outfile.is_open()){
 	  
 	  while (1) {
@@ -207,14 +207,15 @@ int main(int argc, char* argv[]){
 	      int64_t more;
 	      size_t size = sizeof(int64_t);
 	      ftp.getsockopt(ZMQ_RCVMORE, &more, &size);
-	      std::istringstream filess(static_cast<char*>(file.data()));
+	      //std::istringstream filess(static_cast<char*>(file.data());
 	      //  char *tmp=static_cast<char*>(file.data());
 	      //	std::cout<<"buf before = "<<filess.rdbuf()<<std::endl;
 	      //	filess>>tmp;	  
 	      //std::string tmp2;
 	    // filess>>tmp2;
 	    //std::cout<<"received = "<<tmp<<std::endl;
-	      outfile<<filess.rdbuf()<<"\n";
+	      outfile.write(static_cast<const char*>(file.data()),file.size());
+              outfile<<"\n";
 	      // std::cout<<"received part"<<std::endl;
 	      //file.rebuild();
 	      if (!more) break;

--- a/src/RemoteControl/MCDebug.cpp
+++ b/src/RemoteControl/MCDebug.cpp
@@ -103,7 +103,7 @@ int main(){
 	//	break;
 	//} 
 	//else if (cnt > 0){
-    printf("%s: message = \"%s\"\n", inet_ntoa(addr.sin_addr), message);
+    printf("%s: message = \"%.*s\"\n", inet_ntoa(addr.sin_addr), cnt, message);
 	
 	//if(message[0]!='[') break;
 	

--- a/src/RemoteControl/RemoteControl.cpp
+++ b/src/RemoteControl/RemoteControl.cpp
@@ -78,7 +78,8 @@ int main(int argc, char** argv){
       
       zmq::message_t receive;
       Ireceive.recv(&receive);
-      std::istringstream iss(static_cast<char*>(receive.data()));
+      std::string ss(static_cast<char*>(receive.data()),receive.size());
+      std::istringstream iss(ss);
       
       int size;
       iss>>size;
@@ -97,8 +98,8 @@ int main(int argc, char** argv){
 	zmq::message_t servicem;
 	Ireceive.recv(&servicem);
 	
-	std::istringstream ss(static_cast<char*>(servicem.data()));
-	service->JsonParser(ss.str());
+	std::string ss(static_cast<char*>(servicem.data()),servicem.size());
+	service->JsonParser(ss);
 	std::string name;
 	name=(*service).Get<std::string>("msg_value");
 	
@@ -236,10 +237,7 @@ int main(int argc, char** argv){
 	  
 	  zmq::message_t receive;
 	  if(ServiceSend.recv(&receive)){
-	    std::istringstream iss(static_cast<char*>(receive.data()));
-	    
-	    std::string answer;
-	    answer=iss.str();
+	    std::string answer(static_cast<char*>(receive.data()),receive.size());
 	    
 	    Store rr;
 	    rr.JsonParser(answer);
@@ -364,10 +362,7 @@ int main(int argc, char** argv){
 	    
 	    zmq::message_t receive;
 	    if(ServiceSend.recv(&receive)){
-	      std::istringstream iss(static_cast<char*>(receive.data()));
-	      
-	      std::string answer;
-	      answer=iss.str();
+	      std::string answer(static_cast<char*>(receive.data()),receive.size());
 	      
 	      Store rr;
 	      rr.JsonParser(answer);

--- a/src/ServiceDiscovery/ServiceDiscovery.cpp
+++ b/src/ServiceDiscovery/ServiceDiscovery.cpp
@@ -169,7 +169,8 @@ void* ServiceDiscovery::MulticastPublishThread(void* arg){
       zmq::message_t commands;
       Ireceive.recv(&commands);
       
-      std::istringstream tmp(static_cast<char*>(commands.data()));
+      std::string stmp(static_cast<char*>(commands.data()),commands.size());
+      std::istringstream tmp(stmp);
       std::string command;
       std::string service;
       boost::uuids::uuid uuid;
@@ -324,9 +325,9 @@ void* ServiceDiscovery::MulticastPublishThread(void* arg){
             if(in[0].revents & ZMQ_POLLIN){
               zmq::message_t Ereceive;
               StatusCheck.recv (&Ereceive);
-              std::istringstream ss(static_cast<char*>(Ereceive.data()));
+              std::string ss(static_cast<char*>(Ereceive.data()),Ereceive.size());
               
-              mm.JsonParser(ss.str());
+              mm.JsonParser(ss);
             }
           }
         }
@@ -580,7 +581,7 @@ void* ServiceDiscovery::MulticastListenThread(void* arg){
           
           Store* newservice= new Store();
           newservice->Set("ip",inet_ntoa(addr.at(i).sin_addr));
-          newservice->JsonParser(message);
+          newservice->JsonParser(std::string(&message[0],cnt));
           
           std::string uuid;
           newservice->Get("uuid",uuid);
@@ -665,7 +666,8 @@ void* ServiceDiscovery::MulticastListenThread(void* arg){
       
       if(Ireceive.recv(&comm)){
         
-        std::istringstream iss(static_cast<char*>(comm.data()));
+        std::string ss(static_cast<char*>(comm.data()),comm.size());
+        std::istringstream iss(ss);
         std::string arg1="";
         std::string arg2="";
         
@@ -676,9 +678,10 @@ void* ServiceDiscovery::MulticastListenThread(void* arg){
           //printf("d2\n");
           //zmq::message_t sizem(512);
           int size= RemoteServices.size();
-          zmq::message_t sizem(sizeof size);
+          std::string sizes = std::to_string(size);
+          zmq::message_t sizem(sizes.length()+1);
           
-          snprintf ((char *) sizem.data(), sizeof size , "%d" ,size) ;
+          snprintf ((char *) sizem.data(), sizes.length()+1 , "%d" ,size) ;
           
           //           zmq::poll(out,1,1000);
           

--- a/src/ServiceDiscovery/SlowControlCollection.cpp
+++ b/src/ServiceDiscovery/SlowControlCollection.cpp
@@ -244,10 +244,10 @@ void SlowControlCollection::Thread(Thread_args* arg){
       return;
     }
     
-    std::istringstream iss(static_cast<char*>(message.data()));
+    std::string iss(static_cast<char*>(message.data()),message.size());
     Store tmp;
-    //printf("iss=%s\n",iss.str().c_str());
-    tmp.JsonParser(iss.str());
+    //printf("iss=%s\n",iss.c_str());
+    tmp.JsonParser(iss);
     //tmp.Print();
     if(!tmp.Has("msg_value")){
       std::cerr<<"error: Poorly formatted slowcontrol input [no msg_value]"<<std::endl;
@@ -352,7 +352,7 @@ void SlowControlCollection::Thread(Thread_args* arg){
       // FIXME this case should be handled! what do we do?
       std::cerr<<"failed to receive alert!"<<std::endl;
     }
-    std::istringstream iss(static_cast<char*>(message.data()));
+    std::string iss(static_cast<char*>(message.data()),message.size());
     
     // receive alert payload
     std::string payload;
@@ -363,15 +363,14 @@ void SlowControlCollection::Thread(Thread_args* arg){
         // FIXME this case should be handled! what do we do?
         std::cerr<<"failed to receive alert payload!"<<std::endl;
       }
-      payload.resize(message.size(),'\0');
-      memcpy((void*)payload.data(),message.data(),message.size());
+      payload = std::string(static_cast<char*>(message.data()),message.size());
       has_data=true;
     }
     
-    //std::cout<<iss.str()<<std::endl;
+    //std::cout<<iss<<std::endl;
     args->alert_functions_mutex->lock();
-    if(iss.str() == "LoadConfig") (*args->SC_vars)["Config"]->SetValue((int)ConfigState::LoadStart);
-    else if(iss.str() == "ChangeConfig"){
+    if(iss == "LoadConfig") (*args->SC_vars)["Config"]->SetValue((int)ConfigState::LoadStart);
+    else if(iss == "ChangeConfig"){
       if((*args->SC_vars)["NewConfig"]->GetValue<int>() == 0) return;
       (*args->SC_vars)["Config"]->SetValue((int)ConfigState::ChangeStart);
     }
@@ -379,19 +378,19 @@ void SlowControlCollection::Thread(Thread_args* arg){
 
     bool error = false;
     
-    if(args->alert_functions->count(iss.str())){
+    if(args->alert_functions->count(iss)){
       if(has_data){
 	try{
-	  error = !((*(args->alert_functions))[iss.str()](iss.str().c_str(), payload.c_str()));
+	  error = !((*(args->alert_functions))[iss](iss.c_str(), payload.c_str()));
 	}
 	catch(...){
 	  error = true;  
 	}
-	if(iss.str() == "LoadConfig"){
+	if(iss == "LoadConfig"){
 	  if(error)(*args->SC_vars)["Config"]->SetValue((int)ConfigState::LoadFail);
 	  else (*args->SC_vars)["Config"]->SetValue((int)ConfigState::LoadEnd);
 	}
-	else if(iss.str() == "ChangeConfig"){
+	else if(iss == "ChangeConfig"){
 	  if(error)(*args->SC_vars)["Config"]->SetValue((int)ConfigState::ChangeFail);
 	  else (*args->SC_vars)["Config"]->SetValue((int)ConfigState::ChangeEnd);
 	  (*args->SC_vars)["NewConfig"]->SetValue(0);
@@ -400,13 +399,13 @@ void SlowControlCollection::Thread(Thread_args* arg){
       }
       else         
 	try{
-	  error=!((*(args->alert_functions))[iss.str()](iss.str().c_str(), 0));
+	  error=!((*(args->alert_functions))[iss](iss.c_str(), 0));
 	}
 	catch(...){
 	  error = true;
 	}
    
-      if(error)   std::cerr<<"alert fucntion failed: "<<iss.str().c_str()<<std::endl;
+      if(error)   std::cerr<<"alert fucntion failed: "<<iss.c_str()<<std::endl;
 	
 
  }

--- a/src/ToolDAQChain/ToolDAQChain.cpp
+++ b/src/ToolDAQChain/ToolDAQChain.cpp
@@ -246,8 +246,7 @@ void ToolDAQChain::Remote(){
     std::string command="";
     if(Ireceiver.recv(&message, ZMQ_NOBLOCK)){
       
-      std::istringstream iss(static_cast<char*>(message.data()));
-      command=iss.str();
+      command = std::string(static_cast<char*>(message.data()),message.size());
 
       Store rr;
       rr.JsonParser(command);


### PR DESCRIPTION
std::stringstream expects its input to be null terminated.
Unless we guarantee that all zmq messages received are null terminated, this could lead to the stringstream reading past the end of the message and into arbitrary data, risking segfaulting. 
This replaces all instances i could find of std::stringstream for zmq message parsing with a std::string construction that takes the message size. A stringstream is subsequently constructed from this string in the couple of instances where the streamer extraction operator is used. 